### PR TITLE
Fixed syntax error with file-server

### DIFF
--- a/src/file-server.js
+++ b/src/file-server.js
@@ -36,7 +36,7 @@ module.exports = class FileServer {
     this.server = null;
   }
 
-  start = async () => {
+  async start() {
     const server = createFileServer(this.mountDirectory);
 
     return new Promise((resolve) => {
@@ -50,7 +50,7 @@ module.exports = class FileServer {
     })
   }
 
-  stop = async () => {
+  async stop() {
     return new Promise((resolve) => {
       this.server.close(() => {
         resolve();


### PR DESCRIPTION
npm link wasn't working correctly on my machine which resulted in some broken syntax to go unchecked when I was testing it locally.