### PR TITLE
Bump ModelViewer to 0.8 and refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ To start taking screenshots of GLB files
 ```sh
 $ screenshot-glb
 Options:
-  --help        Show help                                              [boolean]
-  --version     Show version number                                    [boolean]
-  -i, --input   Input glTF 2.0 binary (GLB) filepath                  [required]
-  -o, --output  Output PNG screenshot filepath                        [required]
-  -w, --width   Output image width
-  -h, --height  Output image height
+  --help         Show help                                              [boolean]
+  --version      Show version number                                    [boolean]
+  -i, --input    Input glTF 2.0 binary (GLB) filepath                  [required]
+  -o, --output   Output PNG screenshot filepath                        [required]
+  -w, --width    Output image width
+  -h, --height   Output image height
+  -t, --timeout  Timeout length
 ```
 
 ## Dependencies

--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,24 @@
+---
+name: screenshot-glb
+
+type: node
+
+up:
+  - railgun
+  - node:
+      version: v8.16.0
+      yarn: true
+      packages:
+        - .
+
+commands:
+  server:
+    aliases: [s]
+    run: yarn server
+
+  build: yarn build
+
+  test: yarn lint && yarn test
+
+open:
+  "My Application": https://screenshot-glb.myshopify.io

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "author": "Stephan Leroux <stephan.leroux@shopify.com>",
   "license": "MIT",
   "dependencies": {
-    "@google/model-viewer": "^0.6.2",
-    "puppeteer": "^1.19.0",
+    "@google/model-viewer": "^0.8.0",
+    "puppeteer": "^2.1.1",
     "yargs": "^13.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/screenshot-glb",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "publishConfig": {
     "access": "public"
   },

--- a/railgun.yml
+++ b/railgun.yml
@@ -1,0 +1,17 @@
+---
+name: screenshot-glb
+
+vm:
+  image: /opt/dev/misc/railgun-images/default
+  ip_address: 192.168.64.182
+  memory: 2G
+  cores: 2
+
+volumes:
+  root: '2G'
+
+services:
+  - nginx
+
+hostnames:
+  - screenshot-glb.myshopify.io: {proxy_to_host_port: 7000}

--- a/src/file-server.js
+++ b/src/file-server.js
@@ -12,18 +12,22 @@ const createFileServer = (mountDirectory) => {
     };
 
     const contentType = mimeTypes[extname] || 'application/octet-stream';
+    const headers = {
+      'Content-Type': contentType, 
+      'Access-Control-Allow-Origin': '*'
+    }
 
     fs.readFile(filePath, (error, content) => {
       if (error) {
         if(error.code == 'ENOENT') {
-          response.writeHead(404, { 'Content-Type': contentType });
+          response.writeHead(404, headers);
           response.end('File not found', 'utf-8');
         } else {
           response.writeHead(500);
           response.end('Sorry, check with the site admin for error: '+error.code+' ..\n');
         }
       } else {
-        response.writeHead(200, { 'Content-Type': contentType });
+        response.writeHead(200, headers);
         response.end(content, 'utf-8');
       }
     });

--- a/src/start-browser.js
+++ b/src/start-browser.js
@@ -1,6 +1,5 @@
 const puppeteer = require('puppeteer');
 const fs = require('fs');
-const path = require('path');
 
 const parseDataUrl = (dataUrl) => {
   const matches = dataUrl.match(/^data:(.+);base64,(.+)$/);
@@ -36,8 +35,8 @@ const htmlTemplate = ({width, height, libPort}) => {
 module.exports = async ({width, height, libPort}) => {
   const browser = await puppeteer.launch({
     args: [
-      '--disable-web-security',
-      '--user-data-dir',
+      '--disable-web-security', 
+      '--user-data-dir', 
       '--no-sandbox',
     ],
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,20 +2,35 @@
 # yarn lockfile v1
 
 
-"@google/model-viewer@^0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@google/model-viewer/-/model-viewer-0.6.2.tgz#61029d7ee5986c83ff8ab98b5c8fbc01785072de"
-  integrity sha512-+58JkYks8Y+wnlCpOP8Z+WZcQGG9/jrwO2u1bEi19YYtBOXbwDLrjb0iFe+9puKdYi3hsVEH0zmyKaHuk5R6SA==
+"@google/model-viewer@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@google/model-viewer/-/model-viewer-0.8.1.tgz#12527f17fde187e6d935799b54652c53738ac55a"
+  integrity sha512-6smJoYwcLTTqiPfegw5yvmJh+8l0MULYTwbvtac254L6fYZMYWWikTShQ3Srj5iiHapFOv57nCojl54e8Lgy8Q==
   dependencies:
+    "@types/resize-observer-browser" "^0.1.2"
+    "@types/webgl2" "^0.0.5"
     lit-element "^2.2.0"
-    three "^0.105.2"
+    three "^0.110.0"
 
-agent-base@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
-  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
-  dependencies:
-    es6-promisify "^5.0.0"
+"@types/mime-types@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/mime-types/-/mime-types-2.1.0.tgz#9ca52cda363f699c69466c2a6ccdaad913ea7a73"
+  integrity sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=
+
+"@types/resize-observer-browser@^0.1.2":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@types/resize-observer-browser/-/resize-observer-browser-0.1.3.tgz#5cca2445e6fc34a380760bd6ef8c492863469c47"
+  integrity sha512-3tGjLIDH8L57fWOfC7NVn/BbGQD7pXwbkk2+8Z4hK/S7kOIv1MUN4nkKjfx0qg4ctkukjzp3Bgr/Z+Hq5ZQZTQ==
+
+"@types/webgl2@^0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@types/webgl2/-/webgl2-0.0.5.tgz#dd925e20ab8ace80eb4b1e46fda5b109c508fb0d"
+  integrity sha512-oGaKsBbxQOY5+aJFV3KECDhGaXt+yZJt2y/OZsnQGLRkH6Fvr7rv4pCt3SRH1somIHfej/c4u7NSpCyd9x+1Ow==
+
+agent-base@5:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
+  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
 
 ansi-regex@^4.1.0:
   version "4.1.0"
@@ -105,14 +120,7 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.1.0:
+debug@4, debug@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -128,18 +136,6 @@ emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
-
-es6-promise@^4.0.3:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
-  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
-
-es6-promisify@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
-  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
-  dependencies:
-    es6-promise "^4.0.3"
 
 extract-zip@^1.6.6:
   version "1.6.7"
@@ -187,13 +183,13 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-https-proxy-agent@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz#271ea8e90f836ac9f119daccd39c19ff7dfb0793"
-  integrity sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==
+https-proxy-agent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
+  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
   dependencies:
-    agent-base "^4.3.0"
-    debug "^3.1.0"
+    agent-base "5"
+    debug "4"
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -237,6 +233,18 @@ locate-path@^3.0.0:
   dependencies:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
+
+mime-db@1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.43.0.tgz#0a12e0502650e473d735535050e7c8f4eb4fae58"
+  integrity sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==
+
+mime-types@^2.1.25:
+  version "2.1.26"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.26.tgz#9c921fc09b7e149a65dfdc0da4d20997200b0a06"
+  integrity sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==
+  dependencies:
+    mime-db "1.43.0"
 
 mime@^2.0.3:
   version "2.4.4"
@@ -328,15 +336,17 @@ proxy-from-env@^1.0.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
   integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
 
-puppeteer@^1.19.0:
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.19.0.tgz#e3b7b448c2c97933517078d7a2c53687361bebea"
-  integrity sha512-2S6E6ygpoqcECaagDbBopoSOPDv0pAZvTbnBgUY+6hq0/XDFDOLEMNlHF/SKJlzcaZ9ckiKjKDuueWI3FN/WXw==
+puppeteer@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-2.1.1.tgz#ccde47c2a688f131883b50f2d697bd25189da27e"
+  integrity sha512-LWzaDVQkk1EPiuYeTOj+CZRIjda4k2s5w4MK4xoH2+kgWV/SDlkYHmxatDdtYrciHUKSXTsGgPgPP8ILVdBsxg==
   dependencies:
+    "@types/mime-types" "^2.1.0"
     debug "^4.1.0"
     extract-zip "^1.6.6"
-    https-proxy-agent "^2.2.1"
+    https-proxy-agent "^4.0.0"
     mime "^2.0.3"
+    mime-types "^2.1.25"
     progress "^2.0.1"
     proxy-from-env "^1.0.0"
     rimraf "^2.6.1"
@@ -405,10 +415,10 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   dependencies:
     ansi-regex "^4.1.0"
 
-three@^0.105.2:
-  version "0.105.2"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.105.2.tgz#d135f1549bdcf5a9acd904ba3dbf9198a0268984"
-  integrity sha512-L3Al37k4g3hVbgFFS251UVtIc25chhyN0/RvXzR0C+uIBToV6EKDG+MZzEXm9L2miGUVMK27W46/VkP6WUZXMg==
+three@^0.110.0:
+  version "0.110.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.110.0.tgz#8719591de1336269113ee79f4268ba247b2324f8"
+  integrity sha512-wlurH8XBO9Sd5VIw8nBa+taLR20kqaI4e9FiuMh6tqK8eOS2q2R+ZoUyufbyDTVTHhs8GiTbv0r2CMLkwerFJg==
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
This bumps to model-viewer 0.8.

Closes: https://github.com/Shopify/screenshot-glb/issues/5

In order to bump to 0.8 I had to make some changes to a few areas.

1) 0.8 doesn't work on older chromium versions so I had to bump puppeteer to the latest release. 
  a) Side effect of this is that it respects cors policies now so I had to update the server to allow cross origin requests
2) The timeout code added in #7 did not work from the CLI so I refactored the code to support this as well.
3) We were checking when the model was visible on an interval. However that property may be deprecated in a future release so I have changed it to use the event that is triggered when model visibility is changed.

Tophat Instructions
`npm install screenshot-glb`
`dev up`
`yarn`
`yarn link`
`screenshot-glb -i /Users/tylerrowsell/Downloads/RichMediaAssets/Astronaut/Astronaut.glb -o ~/Downloads/output.png`

Where -i is the model on your computer and -o is where the image should be saved.