### PR TITLE
Refactor model-viewer script injection

### DIFF
--- a/src/start-browser.js
+++ b/src/start-browser.js
@@ -15,9 +15,6 @@ const htmlTemplate = ({width, height, libPort}) => {
   return `
     <html>
       <head>
-        <script type="module"
-          src="http://localhost:${libPort}/model-viewer.js">
-        </script>
         <style>
           #snapshot-viewer {
             width: ${width};


### PR DESCRIPTION
In a previous PR I added the function to copy the the model viewer script to a file server to be accessible in the puppeteer page.  

The relative path for model-viewer doesn't always work.
`../node_modules/@google/model-viewer/dist/model-viewer.js`

If the package that includes `screenshot-glb` also includes `model-viewer` than the relative path does not exist. 

This PR uses puppeteers `addScriptTag` function in order to add the script relative to the current package. 