### PR TITLE
Use Relative ModelViewer Path

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -44,12 +44,15 @@ function copyModelViewer(){
   if (!fs.existsSync(dir)){
       fs.mkdirSync(dir);
   }
-  fs.copyFile(path.resolve(__dirname, '../node_modules/@google/model-viewer/dist/model-viewer.js'), 
-    path.resolve(__dirname, '../lib/model-viewer.js'), (err) => {
-      if (err) throw err;
+
+  const modelViewerDirectory = path.dirname(path.dirname(require.resolve('@google/model-viewer')));
+  const srcFile = path.resolve(modelViewerDirectory, 'dist/model-viewer.js');
+  const destFile = path.resolve(__dirname, '../lib/model-viewer.js');  
+  
+  fs.copyFile(srcFile, destFile, (err) => {
+    if (err) throw err;
   });
 }
-
 
 (async () => {
   copyModelViewer()


### PR DESCRIPTION
Currently when model-viewer is resolved inside another package that also includes model-viewer it is not able to find the package.

This modifies the path `../node_modules/@google/model-viewer/dist/model-viewer.js` to use the `require.resolve` function of node.

The one issue is this returns the `lib` path and we need the `dist` path. So using `path.dirname` twice on the path resolves it to it's relative path.