### PR TITLE
Improve Logging

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -83,6 +83,8 @@ function copyModelViewer(){
   page.exposeFunction('logInfo', (message) => {
     INFO(message)
   });
+
+  page.on('console', msg => INFO("--- Console output: ", msg.text()));
   
   let t3 = performance.now();
   await loadGLBAndScreenshot(page, {

--- a/src/load-glb-and-screenshot.js
+++ b/src/load-glb-and-screenshot.js
@@ -1,20 +1,23 @@
 module.exports = async (page, {glbPath, outputPath, format, quality, timeout}) => {
-  return new Promise((resolve, reject) => {
+  return new Promise(async (resolve, reject) => {
     page.exposeFunction('resolvePromise', resolve);
     page.exposeFunction('rejectPromise', reject);
-    page.evaluate(async (browser_glbPath, browser_outputPath, browser_format, browser_quality, timeout) => {
-      var endTime = Number(new Date()) + timeout;
+    await page.evaluate(async (browser_glbPath, browser_outputPath, browser_format, browser_quality, timeout) => {
+      var startTime = Number(new Date());
+      var endTime = startTime + timeout;
 
       const isTimedOut = function() {
-        const currentTime = Number(new Date())
+        const currentTime = Number(new Date());
         if (currentTime < endTime) {
-          window.logInfo(`Waiting ${endTime - currentTime}ms for model to render...`);
-        }else{
+          window.logInfo(`--- Waited ${currentTime - startTime}ms for model to render. ${endTime - currentTime}ms left until timeout.`);
+        } else {
           window.rejectPromise('Waited until timeout');
         }
       }
 
       modelViewer = document.getElementById('snapshot-viewer');
+      timeoutSet = setInterval(isTimedOut, 1000);
+
       modelViewer.addEventListener('model-visibility', function(){
         const visible = event.detail.visible;
         if(visible){
@@ -22,9 +25,9 @@ module.exports = async (page, {glbPath, outputPath, format, quality, timeout}) =
             modelViewer.toDataURL(browser_format, browser_quality),
             browser_outputPath,
           );
+          clearTimeout(timeoutSet);
           window.resolvePromise();
         }
-        setInterval(isTimedOut, 1000);
       });
       modelViewer.src = browser_glbPath;
     }, glbPath, outputPath, format, quality, timeout);


### PR DESCRIPTION
This PR does two things:

1: **Log chrome's console output**
We were missing the logs that are printed to Chrome's console. Following the puppeteer instructions (https://github.com/puppeteer/puppeteer#debugging-tips), we now also print chrome's console output to stdout.

2: **Bug fix where logs from `load-glb-and-screenshot.js ` were not being printed at all**
It seems like this was caused by how we were handing promises and awaiting. `page.evaluate` returns a promise, which we were not awaiting for. As seen in the "before screenshot" below, we were not printing `Waiting Xms for model to render...` logs at all.

Additionally, we were also not clearing the `setTimeout`. That is also fixed in this PR.


**Before Screenshot** 
![image](https://user-images.githubusercontent.com/8185304/80633010-17beec00-8a26-11ea-900e-bb8ee2a5918b.png)

**After Screenshot**
![image](https://user-images.githubusercontent.com/8185304/80633233-6ec4c100-8a26-11ea-8817-26fcb74fa535.png)




