### PR TITLE
[BugFix] Return a non-zero status code when exiting with failure

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -87,20 +87,21 @@ function copyModelViewer(){
   page.on('console', msg => INFO("--- Console output: ", msg.text()));
   
   let t3 = performance.now();
-  await loadGLBAndScreenshot(page, {
-    glbPath,
-    outputPath: argv.output,
-    format,
-    quality,
-    timeout,
-  }).then(()=>{
+
+  process_status = 0;
+
+  try {
+    await loadGLBAndScreenshot(page, { glbPath, outputPath: argv.output, format, quality, timeout });
     t3 = performance.now();
     INFO("--- Took snapshot of", argv.input, `(${timeDelta(t2, t3)} s)`);
-  }).catch(()=>{
+  } catch (err) {
     t3 = performance.now();
     INFO("--- Failed to take snapshot of", argv.input, `(${timeDelta(t2, t3)} s)`);
-  });
-
+    INFO("--- Error Info Start")
+    INFO(err);
+    INFO("--- Error Info End")
+    process_status = 1;
+  }
 
   await browser.close();
   await libServer.stop();
@@ -108,5 +109,7 @@ function copyModelViewer(){
 
   const t4 = performance.now();
   INFO("--- Stopped local file servers", `(${timeDelta(t3, t4)} s)`);
-  INFO("--- DONE");
+  INFO(`--- DONE. Exiting with status=${process_status}`);
+
+  process.exit(process_status);
 })()


### PR DESCRIPTION
This PR makes sure that the we exit with a non-zero status code on failure, and with zero on success. To properly capture all the errors, I "refactored" some code to make it easier to read and understand. 

I also added additional logging to print the error returned by `loadGLBAndScreenshot`.


🎩  Instructions 🎩 
- Run `src/cli.js -i [INPUT_FILE] -o [OUTPUT_FILE] -f "image/jpeg" -q 1.00 -v`
- Run `echo $?` to make sure the script exited with correct status (zero for success)
- Add `throw new Error("my new error")` somewhere  (for eg, right after `timeoutSet = setInterval(isTimedOut, 1000);`)
- Run the script again
- You should see error logs
- `echo $?` should print a non-zero status