### PR TITLE
Add tests for htmlTemplate

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
+  testPathIgnorePatterns: ["/node_modules/", "./dist"],
 };

--- a/src/capture-screenshot.ts
+++ b/src/capture-screenshot.ts
@@ -1,5 +1,6 @@
 import puppeteer from "puppeteer";
 import { performance } from "perf_hooks";
+import { htmlTemplate, TemplateRenderOptions } from "./html-template";
 
 const devicePixelRatio = 1.0;
 const maxTimeInSec = 30;
@@ -8,39 +9,14 @@ const timeDelta = (start, end) => {
   return ((end - start) / 1000).toPrecision(3);
 };
 
-const htmlTemplate = (options) => {
-  const { width, height, inputPath, libPort, backgroundColor } = options;
-  return `
-    <html>
-      <head>
-        <meta name="viewport" content="width=device-width, initial-scale="${devicePixelRatio}">
-        <script type="module"
-          src="http://localhost:${libPort}/model-viewer.js">
-        </script>
-        <style>
-          body {
-            margin: 0;
-          }
-          model-viewer {
-            --progress-bar-color: transparent;
-            width: ${width};
-            height: ${height};
-          }
-        </style>
-      </head>
-      <body>
-        <model-viewer
-          style="background-color: ${backgroundColor};"
-          background-color=""
-          id="snapshot-viewer"
-          interaction-prompt="none"
-          src="${inputPath}" />
-      </body>
-    </html>
-  `;
-};
+interface CaptureScreenShotOptions extends TemplateRenderOptions {
+  outputPath: string;
+  debug: boolean;
+  quality: number;
+  timeout: number;
+}
 
-export async function captureScreenshot(options) {
+export async function captureScreenshot(options: CaptureScreenShotOptions) {
   const browserT0 = performance.now();
   const { width, height, outputPath, debug, quality, timeout } = options;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,7 +69,7 @@ function copyModelViewer() {
 
   let processStatus = 0;
   try {
-    await captureScreenshot(options);
+    await captureScreenshot({ ...options, devicePixelRatio: 1.0 });
   } catch (err) {
     console.log(`❌ ERROR: ${err}`);
     processStatus = 1;

--- a/src/html-template.test.ts
+++ b/src/html-template.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @jest-environment jsdom
+ */
+import { htmlTemplate } from "./html-template";
+
+describe("htmlTemplate", () => {
+  const defaultOptions = {
+    width: 3051,
+    height: 768,
+    inputPath: "http://localhost:8081/some_model.glb",
+    backgroundColor: "#CAFE00",
+    libPort: 8080,
+    devicePixelRatio: 1.0,
+  };
+
+  describe("style", () => {
+    it("should render", () => {
+      const { width, height } = defaultOptions;
+      document.documentElement.innerHTML = htmlTemplate(defaultOptions);
+
+      expect(document.styleSheets).toHaveLength(1);
+      expect(document.styleSheets[0].cssRules).toHaveLength(2);
+      expect(document.styleSheets[0].cssRules[0].cssText).toEqual(
+        "body {margin: 0;}"
+      );
+      expect(document.styleSheets[0].cssRules[1].cssText).toEqual(
+        `model-viewer {--progress-bar-color: transparent; width: ${width}px; height: ${height}px;}`
+      );
+    });
+
+    it("should handle width and height", () => {
+      const width = 8080;
+      const height = 8888;
+      document.documentElement.innerHTML = htmlTemplate({
+        ...defaultOptions,
+        width,
+        height,
+      });
+
+      expect(document.styleSheets[0].cssRules[1].cssText).toEqual(
+        `model-viewer {--progress-bar-color: transparent; width: ${width}px; height: ${height}px;}`
+      );
+    });
+  });
+
+  describe("meta", () => {
+    it("should render", () => {
+      document.documentElement.innerHTML = htmlTemplate(defaultOptions);
+
+      const metaTags = document.querySelectorAll("meta");
+
+      expect(metaTags).toHaveLength(1);
+      expect(metaTags[0].getAttribute("name")).toBe("viewport");
+      expect(metaTags[0].getAttribute("content")).toBe(
+        `width=device-width, initial-scale=${devicePixelRatio}`
+      );
+    });
+
+    it("should handle devicePixelRatio", () => {
+      const devicePixelRatio = 0.123;
+
+      document.documentElement.innerHTML = htmlTemplate({
+        ...defaultOptions,
+        devicePixelRatio,
+      });
+
+      const metaTag = document.querySelector("meta");
+
+      expect(metaTag.getAttribute("content")).toBe(
+        "width=device-width, initial-scale=0.123"
+      );
+    });
+  });
+
+  describe("script", () => {
+    it("should render", () => {
+      const { libPort } = defaultOptions;
+
+      document.documentElement.innerHTML = htmlTemplate(defaultOptions);
+
+      const scriptTags = document.querySelectorAll("script");
+
+      expect(scriptTags).toHaveLength(1);
+      expect(scriptTags[0].getAttribute("type")).toBe("module");
+      expect(scriptTags[0].getAttribute("src")).toBe(
+        `http://localhost:${libPort}/model-viewer.js`
+      );
+    });
+
+    it("should handle port", () => {
+      const libPort = 8008;
+      document.documentElement.innerHTML = htmlTemplate({
+        ...defaultOptions,
+        libPort,
+      });
+
+      const script = document.querySelector("script");
+
+      expect(script.getAttribute("src")).toBe(
+        `http://localhost:${libPort}/model-viewer.js`
+      );
+    });
+  });
+
+  describe("model-viewer", () => {
+    it("should render", () => {
+      const { inputPath, backgroundColor } = defaultOptions;
+
+      document.documentElement.innerHTML = htmlTemplate(defaultOptions);
+
+      const modelViewers = document.querySelectorAll("model-viewer");
+      expect(modelViewers).toHaveLength(1);
+
+      const modelViewer = modelViewers[0];
+      expect(modelViewer).toBeTruthy();
+
+      expect(modelViewer.getAttribute("id")).toEqual("snapshot-viewer");
+      expect(modelViewer.getAttribute("interaction-prompt")).toEqual("none");
+      expect(modelViewer.getAttribute("src")).toEqual(inputPath);
+      expect(modelViewer.getAttribute("style")).toEqual(
+        `background-color: ${backgroundColor};`
+      );
+    });
+
+    it("should handle inputPath", () => {
+      const inputPath = "new.glb";
+      document.documentElement.innerHTML = htmlTemplate({
+        ...defaultOptions,
+        inputPath,
+      });
+
+      const modelViewer = document.querySelector("model-viewer");
+
+      expect(modelViewer.getAttribute("src")).toEqual(inputPath);
+    });
+
+    it("should handle backgroundColor", () => {
+      const backgroundColor = "#FACE00";
+      document.documentElement.innerHTML = htmlTemplate({
+        ...defaultOptions,
+        backgroundColor,
+      });
+
+      const modelViewer = document.querySelector("model-viewer");
+
+      expect(modelViewer.getAttribute("style")).toEqual(
+        `background-color: ${backgroundColor};`
+      );
+    });
+  });
+});

--- a/src/html-template.ts
+++ b/src/html-template.ts
@@ -1,0 +1,47 @@
+export interface TemplateRenderOptions {
+  width: number;
+  height: number;
+  inputPath: string;
+  libPort: number;
+  backgroundColor: string;
+  devicePixelRatio: number;
+}
+
+export function htmlTemplate({
+  width,
+  height,
+  inputPath,
+  libPort,
+  backgroundColor,
+  devicePixelRatio,
+}: TemplateRenderOptions): string {
+  return `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=${devicePixelRatio}">
+        <script type="module"
+          src="http://localhost:${libPort}/model-viewer.js">
+        </script>
+        <style>
+          body {
+            margin: 0;
+          }
+          model-viewer {
+            --progress-bar-color: transparent;
+            width: ${width}px;
+            height: ${height}px;
+          }
+        </style>
+      </head>
+      <body>
+        <model-viewer
+          style="background-color: ${backgroundColor};"
+          id="snapshot-viewer"
+          interaction-prompt="none"
+          src="${inputPath}"
+        />
+      </body>
+    </html>
+  `;
+}


### PR DESCRIPTION
Merge after #53 

This PR moves the `htmlTemplate` function to it's own file and adds tests around it.