### PR TITLE
Add ability to pass custom attributes to <model-viewer>

### DIFF
--- a/src/capture-screenshot.ts
+++ b/src/capture-screenshot.ts
@@ -2,9 +2,6 @@ import puppeteer from "puppeteer";
 import { performance } from "perf_hooks";
 import { htmlTemplate, TemplateRenderOptions } from "./html-template";
 
-const devicePixelRatio = 1.0;
-const maxTimeInSec = 30;
-
 const timeDelta = (start, end) => {
   return ((end - start) / 1000).toPrecision(3);
 };
@@ -18,13 +15,16 @@ interface CaptureScreenShotOptions extends TemplateRenderOptions {
 
 export async function captureScreenshot(options: CaptureScreenShotOptions) {
   const browserT0 = performance.now();
-  const { width, height, outputPath, debug, quality, timeout } = options;
-
-  let screenshotTimeoutInSec = maxTimeInSec;
-
-  if (timeout) {
-    screenshotTimeoutInSec = timeout / 1000;
-  }
+  const {
+    width,
+    height,
+    outputPath,
+    debug,
+    quality,
+    timeout,
+    devicePixelRatio,
+  } = options;
+  const screenshotTimeoutInSec = timeout / 1000;
 
   const browser = await puppeteer.launch({
     args: ["--no-sandbox"],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,37 +2,83 @@
 
 import path from "path";
 import fs from "fs";
+import yargs from "yargs/yargs";
 
 import { FileServer } from "./file-server";
 import { prepareAppOptions } from "./prepare-app-options";
 import { captureScreenshot } from "./capture-screenshot";
+import {
+  DEFAULT_WIDTH,
+  DEFAULT_HEIGHT,
+  DEFAULT_FORMAT,
+  DEFAULT_QUALITY,
+  DEFAULT_TIMEOUT_MILLISECONDS,
+  DEFAULT_DEBUG,
+  DEFAULT_VERBOSE_LOGGING,
+} from "./defaults";
 
-const argv = require("yargs")
-  .alias("i", "input")
-  .alias("o", "output")
-  .alias("c", "color")
-  .alias("w", "width")
-  .alias("h", "height")
-  .alias("f", "image_format")
-  .alias("q", "image_quality")
-  .alias("t", "timeout")
-  .alias("d", "debug")
-  .count("verbose")
-  .alias("v", "verbose")
-  .describe("i", "Input glTF 2.0 binary (GLB) filepath")
-  .describe("o", "Output screenshot filepath")
-  .describe("w", "Output image width")
-  .describe("h", "Output image height")
-  .describe("f", "Output image format (defaults to 'image/png')")
-  .describe("q", "Quality of the output image (defaults to 0.92)")
-  .describe(
-    "c",
-    "Output image background color (defaults to transparent, accepts HEX or RGB)"
-  )
-  .describe("t", "Timeout length")
-  .describe("v", "Enable verbose logging")
-  .describe("d", "Enable Debug Mode")
-  .demandOption(["i", "o"]).argv;
+const argv = yargs(process.argv.slice(2)).options({
+  input: {
+    type: "string",
+    alias: "i",
+    describe: "Input glTF 2.0 binary (GLB) filepath",
+    demandOption: true,
+  },
+  output: {
+    type: "string",
+    alias: "o",
+    describe: "Output screenshot filepath",
+    demandOption: true,
+  },
+  color: {
+    type: "string",
+    alias: "c",
+    describe:
+      "Output image background color (defaults to transparent, accepts HEX or RGB)",
+  },
+  width: {
+    type: "number",
+    alias: "w",
+    describe: "Output image width",
+    default: DEFAULT_WIDTH,
+  },
+  height: {
+    type: "number",
+    alias: "h",
+    describe: "Output image height",
+    default: DEFAULT_HEIGHT,
+  },
+  image_format: {
+    type: "string",
+    alias: "f",
+    describe: "Output image format (defaults to 'image/png')",
+    default: DEFAULT_FORMAT,
+  },
+  image_quality: {
+    type: "number",
+    alias: "q",
+    describe: "Quality of the output image",
+    default: DEFAULT_QUALITY,
+  },
+  timeout: {
+    type: "number",
+    alias: "t",
+    describe: "Timeout length in milliseconds",
+    default: DEFAULT_TIMEOUT_MILLISECONDS,
+  },
+  debug: {
+    type: "boolean",
+    alias: "d",
+    describe: "Enable Debug Mode",
+    default: DEFAULT_DEBUG,
+  },
+  verbose: {
+    type: "boolean",
+    alias: "v",
+    describe: "Enable verbose logging",
+    default: DEFAULT_VERBOSE_LOGGING,
+  },
+}).argv;
 
 function copyModelViewer() {
   const dir = path.resolve(__dirname, "../lib");

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,0 +1,7 @@
+export const DEFAULT_WIDTH = 1024;
+export const DEFAULT_HEIGHT = 1024;
+export const DEFAULT_FORMAT = "image/png";
+export const DEFAULT_QUALITY = 0.92;
+export const DEFAULT_TIMEOUT_MILLISECONDS = 30 * 1000;
+export const DEFAULT_DEBUG = false;
+export const DEFAULT_VERBOSE_LOGGING = false;

--- a/src/html-template.test.ts
+++ b/src/html-template.test.ts
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+
 import { htmlTemplate } from "./html-template";
 
 describe("htmlTemplate", () => {
@@ -145,6 +146,90 @@ describe("htmlTemplate", () => {
 
       expect(modelViewer.getAttribute("style")).toEqual(
         `background-color: ${backgroundColor};`
+      );
+    });
+
+    it("should pass custom attributes", () => {
+      const modelViewerArgs = {
+        "environment-image": "https://some-url.hdr",
+        exposure: "3",
+      };
+
+      document.documentElement.innerHTML = htmlTemplate({
+        ...defaultOptions,
+        modelViewerArgs,
+      });
+
+      const modelViewer = document.querySelector("model-viewer");
+
+      Object.entries(modelViewerArgs).forEach(([attribute, value]) => {
+        expect(modelViewer.getAttribute(attribute)).toBe(value);
+      });
+    });
+
+    it("cannot overwrite src", () => {
+      const modelViewerArgs = {
+        src: "new-source.glb",
+      };
+
+      expect(() =>
+        htmlTemplate({
+          ...defaultOptions,
+          modelViewerArgs,
+        })
+      ).toThrow(
+        new Error("`src` cannot be ovewritten pass the source via -i instead")
+      );
+    });
+
+    it("cannot overwrite id", () => {
+      const modelViewerArgs = {
+        id: "an-id",
+      };
+
+      expect(() =>
+        htmlTemplate({
+          ...defaultOptions,
+          modelViewerArgs,
+        })
+      ).toThrow(
+        new Error(
+          "`id` cannot be passed since it would cause the renderer to break"
+        )
+      );
+    });
+
+    it("cannot overwrite interaction-prompt", () => {
+      const modelViewerArgs = {
+        "interaction-prompt": "when-focused",
+      };
+
+      expect(() =>
+        htmlTemplate({
+          ...defaultOptions,
+          modelViewerArgs,
+        })
+      ).toThrow(
+        new Error(
+          "`interaction-prompt` cannot be passed since it would cause unexpected renders"
+        )
+      );
+    });
+
+    it("cannot overwrite style", () => {
+      const modelViewerArgs = {
+        style: "color: #FF00FF",
+      };
+
+      expect(() =>
+        htmlTemplate({
+          ...defaultOptions,
+          modelViewerArgs,
+        })
+      ).toThrow(
+        new Error(
+          "`style` cannot be passed since it would cause unexpected renders"
+        )
       );
     });
   });

--- a/src/prepare-app-options.test.ts
+++ b/src/prepare-app-options.test.ts
@@ -22,6 +22,10 @@ function getArgv(optionalAndOverrides = {}) {
     input: "./some_model.glb",
     output: "./some_image.png",
     image_format: "image/png",
+    width: 1024,
+    height: 1024,
+    image_quality: 0.92,
+    timeout: 10000,
   };
 
   return {
@@ -29,14 +33,6 @@ function getArgv(optionalAndOverrides = {}) {
     ...optionalAndOverrides,
   };
 }
-
-test("handles defaults", () => {
-  const argv = getArgv();
-
-  expect(prepareAppOptions({ libPort, modelPort, debug, argv })).toEqual(
-    defaultPreparedOptions
-  );
-});
 
 test("handles args", () => {
   const argv = getArgv({

--- a/src/prepare-app-options.ts
+++ b/src/prepare-app-options.ts
@@ -7,11 +7,11 @@ interface Argv {
   input: string;
   output: string;
   image_format: string;
+  image_quality: number;
+  timeout: number;
+  width: number;
+  height: number;
   color?: string;
-  image_quality?: number;
-  timeout?: number;
-  width?: number;
-  height?: number;
 }
 
 interface Props {
@@ -22,20 +22,28 @@ interface Props {
 }
 
 export function prepareAppOptions({ libPort, modelPort, debug, argv }: Props) {
-  const inputPath = `http://localhost:${modelPort}/${path.basename(
-    argv.input
-  )}`;
-  const [outputPath, format] = scrubOutput(argv.output, argv.image_format);
+  const {
+    input,
+    output,
+    image_format,
+    image_quality: quality,
+    timeout,
+    height,
+    width,
+    color: backgroundColor,
+  } = argv;
+  const inputPath = `http://localhost:${modelPort}/${path.basename(input)}`;
+  const [outputPath, format] = scrubOutput(output, image_format);
   const defaultBackgroundColor =
     format === "image/jpeg" ? colors.white : colors.transparent;
 
   return {
-    backgroundColor: argv.color || defaultBackgroundColor,
-    quality: argv.image_quality || 0.92,
-    timeout: argv.timeout || 10000,
-    height: argv.height || 1024,
-    width: argv.width || 1024,
-    debug: debug || false,
+    backgroundColor: backgroundColor || defaultBackgroundColor,
+    quality,
+    timeout,
+    height,
+    width,
+    debug,
     inputPath,
     outputPath,
     format,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "moduleResolution": "node",
     "sourceMap": true,
     "outDir": "dist",
-    "noEmitHelpers": false
+    "noEmitHelpers": false,
+    "removeComments": false
   },
   "exclude": ["node_modules"],
   "lib": ["es2015"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2614,6 +2614,15 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
@@ -2627,6 +2636,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@^4.0.0:
   version "4.0.0"
@@ -2969,6 +2985,11 @@ yargs-parser@^20.2.2:
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.7.tgz"
   integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
 
+yargs-parser@^21.0.0:
+  version "21.0.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.0.tgz#a485d3966be4317426dd56bdb6a30131b281dc55"
+  integrity sha512-z9kApYUOCwoeZ78rfRYYWdiU/iNL6mwwYlkkZfJoyMR1xps+NEBX5X7XmRpxkZHhXJ6+Ey00IwKxBBSW9FIjyA==
+
 yargs@^16.2.0:
   version "16.2.0"
   resolved "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz"
@@ -2983,17 +3004,17 @@ yargs@^16.2.0:
     yargs-parser "^20.2.2"
 
 yargs@^17.2.1:
-  version "17.2.1"
-  resolved "https://registry.npmjs.org/yargs/-/yargs-17.2.1.tgz"
-  integrity sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==
+  version "17.3.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.3.1.tgz#da56b28f32e2fd45aefb402ed9c26f42be4c07b9"
+  integrity sha512-WUANQeVgjLbNsEmGk20f+nlHgOqzRFpiGWVaBrYGYIGANIIu3lWjoyi0fNlFmJkvfhCZ6BXINe7/W2O2bV4iaA==
   dependencies:
     cliui "^7.0.2"
     escalade "^3.1.1"
     get-caller-file "^2.0.5"
     require-directory "^2.1.1"
-    string-width "^4.2.0"
+    string-width "^4.2.3"
     y18n "^5.0.5"
-    yargs-parser "^20.2.2"
+    yargs-parser "^21.0.0"
 
 yauzl@^2.10.0:
   version "2.10.0"


### PR DESCRIPTION
Merge after #54 

This PR adds the ability to pass in an Object to the `htmlTemplate` function which will pass custom arguments to the `<model-viewer>` element.

It should be noted that I prevent the user from passing in arguments that would overwrite the default arguments.