### PR TITLE
Pass model viewer attributes through cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "lint": "echo \"linting not implemented\"",
     "test": "jest",
-    "dev": "yarn build && node dist/cli.js -i ./test/fixtures/WaterBottle.glb -o output.jpg -f image/jpeg -q 1.00 -v -t 30000"
+    "dev": "yarn build && node dist/cli.js -i ./test/fixtures/WaterBottle.glb -o output.jpg -w 1024 -h 2048 -f image/jpeg -q 1.00 -v -t 30000 -m \"exposure=0.92&camera-orbit=88.59deg 59.01deg 0.24m&camera-target=0.06m 0.04m 0m&environment-image=neutral\""
   },
   "author": "Stephan Leroux <stephan.leroux@shopify.com>",
   "license": "MIT",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -78,6 +78,12 @@ const argv = yargs(process.argv.slice(2)).options({
     describe: "Enable verbose logging",
     default: DEFAULT_VERBOSE_LOGGING,
   },
+  model_viewer_attributes: {
+    type: "string",
+    alias: "m",
+    describe:
+      "Set <model-viewer> attributes by passing them as url params eg. exposure=2&environment-image=neutral",
+  },
 }).argv;
 
 function copyModelViewer() {

--- a/src/prepare-app-options.test.ts
+++ b/src/prepare-app-options.test.ts
@@ -81,3 +81,16 @@ test("handles jpg with color override", () => {
     backgroundColor: "rgba(255, 0, 255, 1)",
   });
 });
+
+test("handles model viewer attributes", () => {
+  const argv = getArgv({
+    model_viewer_attributes: "exposure=10&camera-orbit=45deg 55deg 2.5m",
+  });
+  expect(prepareAppOptions({ libPort, modelPort, debug, argv })).toEqual({
+    ...defaultPreparedOptions,
+    modelViewerArgs: {
+      "camera-orbit": "45deg 55deg 2.5m",
+      exposure: "10",
+    },
+  });
+});

--- a/src/prepare-app-options.ts
+++ b/src/prepare-app-options.ts
@@ -12,6 +12,7 @@ interface Argv {
   width: number;
   height: number;
   color?: string;
+  model_viewer_attributes?: string;
 }
 
 interface Props {
@@ -31,11 +32,22 @@ export function prepareAppOptions({ libPort, modelPort, debug, argv }: Props) {
     height,
     width,
     color: backgroundColor,
+    model_viewer_attributes,
   } = argv;
   const inputPath = `http://localhost:${modelPort}/${path.basename(input)}`;
   const [outputPath, format] = scrubOutput(output, image_format);
   const defaultBackgroundColor =
     format === "image/jpeg" ? colors.white : colors.transparent;
+  let modelViewerArgs: { [key: string]: string } = undefined;
+
+  if (model_viewer_attributes) {
+    modelViewerArgs = {};
+
+    const params = new URLSearchParams(model_viewer_attributes);
+    params.forEach((value, key) => {
+      modelViewerArgs[key] = value;
+    });
+  }
 
   return {
     backgroundColor: backgroundColor || defaultBackgroundColor,
@@ -48,5 +60,6 @@ export function prepareAppOptions({ libPort, modelPort, debug, argv }: Props) {
     outputPath,
     format,
     libPort,
+    modelViewerArgs,
   };
 }


### PR DESCRIPTION
Fixes https://github.com/Shopify/threed-model-service/issues/1891

Merge after #55 

This PR makes it so you can pass Model Viewer attributes through the CLI like this:
```
$ screenshot-glb WaterBottle.glb -o output.jpg -m "exposure=2&camera-orbit=88.59deg 59.01deg 0.24m"
```