### PR TITLE
1.6.0 - `model_viewer_attributes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,62 +26,65 @@ Options:
 
 ## Dependencies
 
-The module relies on using [puppeteer](https://www.npmjs.com/package/puppeteer) to spawn a headless instance of Chrome to render Google's [<model-viewer>](https://github.com/GoogleWebComponents/model-viewer) web component with the GLB model loaded. 
+The module relies on using [puppeteer](https://www.npmjs.com/package/puppeteer) to spawn a headless instance of Chrome to render Google's [<model-viewer>](https://github.com/GoogleWebComponents/model-viewer) web component with the GLB model loaded.
 
 ## Development
 
 For Shopify Employees
+
 - `dev up`
 - `yarn link`
+- You may need to need to do `chmod 755 dist/cli.js` to allow for execution
 - `screenshot-glb -i <PATH_TO_MODEL> -o <PATH_TO_OUTPUT_IMAGE>`
 
 Outside Development
+
 - `yarn install`
 - `yarn link`
 - `screenshot-glb -i <PATH_TO_MODEL> -o <PATH_TO_OUTPUT_IMAGE>`
-  
+
 ### Linux
 
 You may need to install the following packages in order for the headless Chrome instance to work on headless Linux VM machines:
 
 ```
-gconf-service 
-libasound2 
-libatk1.0-0 
-libatk-bridge2.0-0 
-libc6 
-libcairo2 
-libcups2 
-libdbus-1-3 
-libexpat1 
-libfontconfig1 
-libgcc1 
-libgconf-2-4 
+gconf-service
+libasound2
+libatk1.0-0
+libatk-bridge2.0-0
+libc6
+libcairo2
+libcups2
+libdbus-1-3
+libexpat1
+libfontconfig1
+libgcc1
+libgconf-2-4
 libgdk-pixbuf2.0-0
-libglib2.0-0 
+libglib2.0-0
 libgtk-3-0
 libnspr4
 libpango-1.0-0
 libpangocairo-1.0-0
-libstdc++6 
-libx11-6 
-libx11-xcb1 
-libxcb1 
-libxcomposite1 
-libxcursor1 
-libxdamage1 
-libxext6 
-libxfixes3 
-libxi6 
-libxrandr2 
+libstdc++6
+libx11-6
+libx11-xcb1
+libxcb1
+libxcomposite1
+libxcursor1
+libxdamage1
+libxext6
+libxfixes3
+libxi6
+libxrandr2
 libxrender1
-libxss1 
-libxtst6 
-ca-certificates 
-fonts-liberation 
-libappindicator1 
-libnss3 
-lsb-release 
+libxss1
+libxtst6
+ca-certificates
+fonts-liberation
+libappindicator1
+libnss3
+lsb-release
 xdg-utils
 wget
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopify/screenshot-glb",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
This bumps the minor version so we can distribute the CLI tool with `model_viewer_attributes`