### PR TITLE
Made model viewer load from cdn

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "build": "tsc",
     "lint": "echo \"linting not implemented\"",
     "test": "jest",
-    "dev": "yarn build && node dist/cli.js -i ./test/fixtures/WaterBottle.glb -o output.jpg -w 1024 -h 2048 -q 1.00 -v -t 30000 -m \"exposure=0.92&camera-orbit=88.59deg 59.01deg 0.24m&camera-target=0.06m 0.04m 0m&environment-image=neutral\""
+    "dev": "yarn build && node dist/cli.js -i ./test/fixtures/WaterBottle.glb -o output.jpg -w 1024 -h 2048 -q 1.00 -v -t 30000 -m \"exposure=0.92&camera-orbit=88.59deg 59.01deg 0.24m&camera-target=0.06m 0.04m 0m&environment-image=neutral\"",
+    "dev:version": "yarn build && node dist/cli.js -i ./test/fixtures/WaterBottle.glb -o output.jpg -@ 1.9 -w 1024 -h 2048 -q 1.00 -v -t 30000 -m \"exposure=0.92&camera-orbit=88.59deg 59.01deg 0.24m&camera-target=0.06m 0.04m 0m&environment-image=neutral\""
   },
   "author": "Stephan Leroux <stephan.leroux@shopify.com>",
   "license": "MIT",
   "dependencies": {
-    "@google/model-viewer": "^1.10.1",
     "mime-types": "^2.1.34",
     "puppeteer": "^11.0.0",
     "yargs": "^17.2.1"

--- a/src/check-file-exists-at-url.test.ts
+++ b/src/check-file-exists-at-url.test.ts
@@ -1,0 +1,14 @@
+import {checkFileExistsAtUrl} from './check-file-exists-at-url';
+
+describe('checkFileExistsAtUrl', () => {
+  const urlExists = 'https://cdn.shopify.com/shopifycloud/model-viewer/model-viewer.js';
+  const urlDoesNotExist = 'https://cdn.shopify.com/shopifycloud/dog-viewer/dog-viewer.js'
+
+  it('should find the file', async () => {
+    await expect(checkFileExistsAtUrl(urlExists)).resolves.toEqual(true);
+  });
+
+  it('should not find the file', async () => {
+    await expect(checkFileExistsAtUrl(urlDoesNotExist)).resolves.toEqual(false);
+  });
+});

--- a/src/check-file-exists-at-url.ts
+++ b/src/check-file-exists-at-url.ts
@@ -1,0 +1,19 @@
+import https from 'https';
+
+export function checkFileExistsAtUrl(url: string): Promise<boolean> {
+  return new Promise((resolve, reject) => {
+    const urlParts = new URL(url);
+    const {
+      hostname,
+      pathname: path,
+    } = urlParts;
+
+    const request = https.get(url);
+
+    request.on('response', ({statusCode}) => {
+      resolve(statusCode === 200);
+    });
+
+    request.on('error', reject);
+  });
+}

--- a/src/get-model-viewer-url.test.ts
+++ b/src/get-model-viewer-url.test.ts
@@ -1,0 +1,39 @@
+import {getModelViewerUrl} from './get-model-viewer-url';
+
+describe('getModelViewerUrl', () => {
+  it('handles default', () => {
+    expect(getModelViewerUrl()).toBe('https://cdn.shopify.com/shopifycloud/model-viewer/model-viewer.js');
+  });
+
+  it('handles passing version', () => {
+    expect(getModelViewerUrl('1.9')).toBe('https://cdn.shopify.com/shopifycloud/model-viewer/v1.9/model-viewer.js');
+  });
+
+  it('handles passing full version', () => {
+    expect(getModelViewerUrl('1.9.1')).toBe('https://cdn.shopify.com/shopifycloud/model-viewer/v1.9/model-viewer.js');
+  });
+
+  it('handles passing with v', () => {
+    expect(getModelViewerUrl('v1.9')).toBe('https://cdn.shopify.com/shopifycloud/model-viewer/v1.9/model-viewer.js');
+  });
+
+  it('handles passing with v and full version', () => {
+    expect(getModelViewerUrl('v1.9.1')).toBe('https://cdn.shopify.com/shopifycloud/model-viewer/v1.9/model-viewer.js');
+  });
+
+  it('handles multi digit', () => {
+    expect(getModelViewerUrl('11.99.1')).toBe('https://cdn.shopify.com/shopifycloud/model-viewer/v11.99/model-viewer.js');
+  });
+
+  it('handles passing with v', () => {
+    expect(getModelViewerUrl('v11.99')).toBe('https://cdn.shopify.com/shopifycloud/model-viewer/v11.99/model-viewer.js');
+  });
+
+  it('handles passing with v and full version', () => {
+    expect(getModelViewerUrl('v11.99.1')).toBe('https://cdn.shopify.com/shopifycloud/model-viewer/v11.99/model-viewer.js');
+  });
+
+  it('handles no version', () => {
+    expect(() => getModelViewerUrl('dogs.are.cool')).toThrow('"dogs.are.cool" was not valid version. Example version: 1.10');
+  });
+});

--- a/src/get-model-viewer-url.ts
+++ b/src/get-model-viewer-url.ts
@@ -1,0 +1,17 @@
+export function getModelViewerUrl(version?: string) {
+  if (!version) {
+    return 'https://cdn.shopify.com/shopifycloud/model-viewer/model-viewer.js';
+  }
+
+  const regexGetVersion = /(\d+\.\d+)(\.\d+)?/;
+
+  const result = regexGetVersion.exec(version);
+
+  if (!result) {
+    throw new Error(`"${version}" was not valid version. Example version: 1.10`);
+  }
+
+  const majorMinor = result[1];
+
+  return `https://cdn.shopify.com/shopifycloud/model-viewer/v${majorMinor}/model-viewer.js`;
+}

--- a/src/html-template.test.ts
+++ b/src/html-template.test.ts
@@ -6,11 +6,11 @@ import { htmlTemplate } from "./html-template";
 
 describe("htmlTemplate", () => {
   const defaultOptions = {
+    modelViewerUrl: 'https://cdn.shopify.com/shopifycloud/model-viewer/model-viewer.js',
     width: 3051,
     height: 768,
     inputPath: "http://localhost:8081/some_model.glb",
     backgroundColor: "#CAFE00",
-    libPort: 8080,
     devicePixelRatio: 1.0,
   };
 
@@ -75,8 +75,6 @@ describe("htmlTemplate", () => {
 
   describe("script", () => {
     it("should render", () => {
-      const { libPort } = defaultOptions;
-
       document.documentElement.innerHTML = htmlTemplate(defaultOptions);
 
       const scriptTags = document.querySelectorAll("script");
@@ -84,21 +82,19 @@ describe("htmlTemplate", () => {
       expect(scriptTags).toHaveLength(1);
       expect(scriptTags[0].getAttribute("type")).toBe("module");
       expect(scriptTags[0].getAttribute("src")).toBe(
-        `http://localhost:${libPort}/model-viewer.js`
+        'https://cdn.shopify.com/shopifycloud/model-viewer/model-viewer.js'
       );
     });
 
     it("should handle port", () => {
-      const libPort = 8008;
       document.documentElement.innerHTML = htmlTemplate({
         ...defaultOptions,
-        libPort,
       });
 
       const script = document.querySelector("script");
 
       expect(script.getAttribute("src")).toBe(
-        `http://localhost:${libPort}/model-viewer.js`
+        'https://cdn.shopify.com/shopifycloud/model-viewer/model-viewer.js'
       );
     });
   });

--- a/src/html-template.ts
+++ b/src/html-template.ts
@@ -1,10 +1,12 @@
+import {getModelViewerUrl} from "./get-model-viewer-url";
+
 type AttributesObject = { [key: string]: any };
 
 export interface TemplateRenderOptions {
+  modelViewerUrl: string;
   width: number;
   height: number;
   inputPath: string;
-  libPort: number;
   backgroundColor: string;
   devicePixelRatio: number;
   modelViewerArgs?: AttributesObject;
@@ -48,10 +50,10 @@ function validateCustomAttributes(
 }
 
 export function htmlTemplate({
+  modelViewerUrl,
   width,
   height,
   inputPath,
-  libPort,
   backgroundColor,
   devicePixelRatio,
   modelViewerArgs,
@@ -74,7 +76,7 @@ export function htmlTemplate({
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=${devicePixelRatio}">
         <script type="module"
-          src="http://localhost:${libPort}/model-viewer.js">
+          src="${modelViewerUrl}">
         </script>
         <style>
           body {

--- a/src/prepare-app-options.test.ts
+++ b/src/prepare-app-options.test.ts
@@ -1,6 +1,5 @@
 import { prepareAppOptions } from "./prepare-app-options";
 
-const libPort = 8080;
 const modelPort = 8081;
 const debug = false;
 
@@ -11,7 +10,6 @@ const defaultPreparedOptions = {
   width: 1024,
   height: 1024,
   inputPath: "http://localhost:8081/some_model.glb",
-  libPort: 8080,
   outputPath: "./some_image.png",
   quality: 0.92,
   timeout: 10000,
@@ -43,7 +41,7 @@ test("handles args", () => {
     color: "rgba(255, 0, 255, 0)",
   });
 
-  expect(prepareAppOptions({ libPort, modelPort, debug, argv })).toEqual({
+  expect(prepareAppOptions({ modelPort, debug, argv })).toEqual({
     ...defaultPreparedOptions,
     backgroundColor: "rgba(255, 0, 255, 0)",
     width: 2048,
@@ -59,7 +57,7 @@ test("handles jpg format", () => {
     image_format: "image/jpeg",
   });
 
-  expect(prepareAppOptions({ libPort, modelPort, debug, argv })).toEqual({
+  expect(prepareAppOptions({ modelPort, debug, argv })).toEqual({
     ...defaultPreparedOptions,
     outputPath: "./some_image.jpg",
     format: "image/jpeg",
@@ -74,7 +72,7 @@ test("handles jpg with color override", () => {
     color: "rgba(255, 0, 255, 1)",
   });
 
-  expect(prepareAppOptions({ libPort, modelPort, debug, argv })).toEqual({
+  expect(prepareAppOptions({ modelPort, debug, argv })).toEqual({
     ...defaultPreparedOptions,
     outputPath: "./some_image.jpg",
     format: "image/jpeg",
@@ -86,7 +84,7 @@ test("handles model viewer attributes", () => {
   const argv = getArgv({
     model_viewer_attributes: "exposure=10&camera-orbit=45deg 55deg 2.5m",
   });
-  expect(prepareAppOptions({ libPort, modelPort, debug, argv })).toEqual({
+  expect(prepareAppOptions({ modelPort, debug, argv })).toEqual({
     ...defaultPreparedOptions,
     modelViewerArgs: {
       "camera-orbit": "45deg 55deg 2.5m",

--- a/src/prepare-app-options.ts
+++ b/src/prepare-app-options.ts
@@ -12,17 +12,17 @@ interface Argv {
   width: number;
   height: number;
   color?: string;
+  model_viewer_version?: string;
   model_viewer_attributes?: string;
 }
 
 interface Props {
-  libPort: number;
   modelPort: number;
   argv: Argv;
   debug?: boolean;
 }
 
-export function prepareAppOptions({ libPort, modelPort, debug, argv }: Props) {
+export function prepareAppOptions({ modelPort, debug, argv }: Props) {
   const {
     input,
     output,
@@ -33,6 +33,7 @@ export function prepareAppOptions({ libPort, modelPort, debug, argv }: Props) {
     width,
     color: backgroundColor,
     model_viewer_attributes,
+    model_viewer_version: modelViewerVersion,
   } = argv;
   const inputPath = `http://localhost:${modelPort}/${path.basename(input)}`;
   const [outputPath, format] = parseOutputPathAndFormat(output, image_format);
@@ -59,7 +60,7 @@ export function prepareAppOptions({ libPort, modelPort, debug, argv }: Props) {
     inputPath,
     outputPath,
     format,
-    libPort,
     modelViewerArgs,
+    modelViewerVersion,
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -481,11 +481,6 @@
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@google/model-viewer@^1.10.1":
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/@google/model-viewer/-/model-viewer-1.10.1.tgz#521d6112685f629514a7fbd1be1dcc476f58c9b1"
-  integrity sha512-mQ7FhALWLj1rc4P7NXUNVG4glfgIeKK18X5UlQ0C+InkTsaLvfdTkOz5ixTwDWaw3ba8j6DMyGcN0mzMqc/OyA==
-
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz"


### PR DESCRIPTION
This PR makes it so that Model Viewer is always loaded from the CDN.

What this means is that we never need to update Model Viewer in this package but rather just update our CDN distribution.

By default Screenshot GLB will use the "latest" version of Model Viewer which is distributed on our CDN:
https://cdn.shopify.com/shopifycloud/model-viewer/model-viewer.js

However the user can pass in a version using the cli params `-@` or `--model_viewer_version`.

I've made it so that you can pass version strings in the following forms:
- `1.10`
- `v1.10`
- `1.10.1`
- `v1.10.1`

Before rendering I also check the file exists on our CDN. So if you pass `1.0` an exception will be thrown.