### PR TITLE
Prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+"@shopify/prettier-config"

--- a/dev.yml
+++ b/dev.yml
@@ -4,7 +4,7 @@ name: screenshot-glb
 type: node
 
 up:
-  - railgun
+  - isogun
   - node:
       version: v16.13.0
       yarn: true

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "prepare": "yarn build",
     "build": "tsc",
-    "lint": "echo \"linting not implemented\"",
+    "lint": "prettier --check ./src",
+    "lint:fix": "prettier --write ./src",
     "test": "jest",
     "dev": "yarn build && node dist/cli.js -i ./test/fixtures/WaterBottle.glb -o output.jpg -w 1024 -h 2048 -q 1.00 -v -t 30000 -m \"exposure=0.92&camera-orbit=88.59deg 59.01deg 0.24m&camera-target=0.06m 0.04m 0m&environment-image=neutral\"",
     "dev:version": "yarn build && node dist/cli.js -i ./test/fixtures/WaterBottle.glb -o output.jpg -@ 1.9 -w 1024 -h 2048 -q 1.00 -v -t 30000 -m \"exposure=0.92&camera-orbit=88.59deg 59.01deg 0.24m&camera-target=0.06m 0.04m 0m&environment-image=neutral\"",
@@ -20,6 +21,7 @@
   "author": "Stephan Leroux <stephan.leroux@shopify.com>",
   "license": "MIT",
   "dependencies": {
+    "@shopify/prettier-config": "^1.1.2",
     "mime-types": "^2.1.34",
     "puppeteer": "^13.7.0",
     "yargs": "^17.2.1"
@@ -27,6 +29,7 @@
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "jest": "^27.4.7",
+    "prettier": "^2.7.1",
     "ts-jest": "^27.1.3",
     "typescript": "^4.5.5"
   }

--- a/src/capture-screenshot.test.ts
+++ b/src/capture-screenshot.test.ts
@@ -1,12 +1,12 @@
 import puppeteer, {Browser, Page} from 'puppeteer';
 import {captureScreenshot} from './capture-screenshot';
-import { htmlTemplate } from "./html-template";
-import { performance } from "perf_hooks";
-import { checkFileExistsAtUrl } from "./check-file-exists-at-url";
+import {htmlTemplate} from './html-template';
+import {performance} from 'perf_hooks';
+import {checkFileExistsAtUrl} from './check-file-exists-at-url';
 
-jest.mock("./html-template");
-jest.mock("./check-file-exists-at-url");
-jest.mock("perf_hooks", () => {
+jest.mock('./html-template');
+jest.mock('./check-file-exists-at-url');
+jest.mock('perf_hooks', () => {
   return {
     performance: {
       now: jest.fn(),
@@ -59,7 +59,7 @@ describe('captureScreenshot', () => {
     formatExtension,
   };
   const htmlContent = '<div>some html</div>';
-  let originalConsoleLog: (typeof console.log);
+  let originalConsoleLog: typeof console.log;
   let mockPage;
   let mockBrowser;
 
@@ -82,7 +82,7 @@ describe('captureScreenshot', () => {
 
   test('calls with correct args', async () => {
     await captureScreenshot({
-      ...defaultParams
+      ...defaultParams,
     });
 
     expect(puppeteer.launch).toHaveBeenCalledWith({
@@ -129,27 +129,24 @@ describe('captureScreenshot', () => {
 
   test('calls setContent', async () => {
     await captureScreenshot({
-      ...defaultParams
+      ...defaultParams,
     });
 
-    expect(mockPage.setContent).toHaveBeenCalledWith(
-      htmlContent,
-      { 
-        waitUntil: ['domcontentloaded', 'networkidle0']
-      }
-    );
+    expect(mockPage.setContent).toHaveBeenCalledWith(htmlContent, {
+      waitUntil: ['domcontentloaded', 'networkidle0'],
+    });
   });
 
   test('logs out correctly', async () => {
     const expectedLogs = [
-      "🚀  Launched browser (0.00s)",
-      "🗺  Loading template to DOMContentLoaded (0.00s)",
-      "🖌  Rendering screenshot of model (0.00s)",
-      "🖼  Captured screenshot (0.00s)",
+      '🚀  Launched browser (0.00s)',
+      '🗺  Loading template to DOMContentLoaded (0.00s)',
+      '🖌  Rendering screenshot of model (0.00s)',
+      '🖼  Captured screenshot (0.00s)',
     ];
 
     await captureScreenshot({
-      ...defaultParams
+      ...defaultParams,
     });
 
     expect(console.log).toHaveBeenCalledTimes(expectedLogs.length);
@@ -161,16 +158,16 @@ describe('captureScreenshot', () => {
   test('handles evaluate error', async () => {
     const error = new Error('some error');
     const expectedLogs = [
-      "🚀  Launched browser (0.00s)",
-      "🗺  Loading template to DOMContentLoaded (0.00s)",
-      "🖌  Rendering screenshot of model (0.00s)",
+      '🚀  Launched browser (0.00s)',
+      '🗺  Loading template to DOMContentLoaded (0.00s)',
+      '🖌  Rendering screenshot of model (0.00s)',
       `❌  Evaluate error: ${error}`,
     ];
 
     mockPage.evaluate.mockResolvedValue(error);
 
     await captureScreenshot({
-      ...defaultParams
+      ...defaultParams,
     });
 
     expect(console.log).toHaveBeenCalledTimes(expectedLogs.length);
@@ -184,10 +181,10 @@ describe('captureScreenshot', () => {
 
   test('adds correct listeners to page', async () => {
     await captureScreenshot({
-      ...defaultParams
+      ...defaultParams,
     });
 
-    const on = (mockPage.on as jest.Mock);
+    const on = mockPage.on as jest.Mock;
     expect(on).toHaveBeenCalledTimes(2);
     expect(on.mock.calls[0][0]).toBe('error');
     expect(on.mock.calls[1][0]).toBe('console');
@@ -197,12 +194,14 @@ describe('captureScreenshot', () => {
     const error = new Error('some error');
     let errorCallback;
 
-    (mockPage.on as jest.Mock).mockImplementation((event: string, callback: (error: Error) => void) => {
-      if (event === 'error') errorCallback = callback;
-    });
+    (mockPage.on as jest.Mock).mockImplementation(
+      (event: string, callback: (error: Error) => void) => {
+        if (event === 'error') errorCallback = callback;
+      },
+    );
 
     await captureScreenshot({
-      ...defaultParams
+      ...defaultParams,
     });
 
     errorCallback(error);
@@ -214,11 +213,11 @@ describe('captureScreenshot', () => {
     (checkFileExistsAtUrl as jest.Mock).mockResolvedValue(false);
 
     await captureScreenshot({
-      ...defaultParams
+      ...defaultParams,
     });
 
     expect(console.log).toHaveBeenLastCalledWith(
-      '❌  Model Viewer error: Error: Unfortunately Model Viewer undefined cannot be used to render a screenshot'
+      '❌  Model Viewer error: Error: Unfortunately Model Viewer undefined cannot be used to render a screenshot',
     );
   });
 });

--- a/src/capture-screenshot.ts
+++ b/src/capture-screenshot.ts
@@ -1,14 +1,15 @@
-import puppeteer from "puppeteer";
-import { performance } from "perf_hooks";
-import { htmlTemplate, TemplateRenderOptions } from "./html-template";
-import { getModelViewerUrl } from "./get-model-viewer-url";
-import { checkFileExistsAtUrl } from "./check-file-exists-at-url";
+import puppeteer from 'puppeteer';
+import {performance} from 'perf_hooks';
+import {htmlTemplate, TemplateRenderOptions} from './html-template';
+import {getModelViewerUrl} from './get-model-viewer-url';
+import {checkFileExistsAtUrl} from './check-file-exists-at-url';
 
 const timeDelta = (start, end) => {
   return ((end - start) / 1000).toPrecision(3);
 };
 
-interface CaptureScreenShotOptions extends Omit<TemplateRenderOptions, 'modelViewerUrl'> {
+interface CaptureScreenShotOptions
+  extends Omit<TemplateRenderOptions, 'modelViewerUrl'> {
   modelViewerVersion?: string;
   outputPath: string;
   debug: boolean;
@@ -63,13 +64,13 @@ export async function captureScreenshot(options: CaptureScreenShotOptions) {
 
   const page = await browser.newPage();
 
-  page.on("error", (error) => {
+  page.on('error', (error) => {
     console.log(`🚨  Page Error: ${error}`);
   });
 
-  page.on("console", async (message) => {
+  page.on('console', async (message) => {
     const args = await Promise.all(
-      message.args().map((arg) => arg.jsonValue())
+      message.args().map((arg) => arg.jsonValue()),
     );
 
     if (args.length) {
@@ -87,22 +88,26 @@ export async function captureScreenshot(options: CaptureScreenShotOptions) {
   const modelViewerUrlExists = await checkFileExistsAtUrl(modelViewerUrl);
 
   if (!modelViewerUrlExists) {
-    logError(`Model Viewer error: ${new Error(
-      `Unfortunately Model Viewer ${modelViewerVersion} cannot be used to render a screenshot`
-    )}`);
+    logError(
+      `Model Viewer error: ${new Error(
+        `Unfortunately Model Viewer ${modelViewerVersion} cannot be used to render a screenshot`,
+      )}`,
+    );
     return;
   }
 
   const data = htmlTemplate({...options, modelViewerUrl});
-  await page.setContent(data, { waitUntil: ['domcontentloaded', 'networkidle0'] });
+  await page.setContent(data, {
+    waitUntil: ['domcontentloaded', 'networkidle0'],
+  });
 
   const contentT1 = performance.now();
 
   console.log(
     `🗺  Loading template to DOMContentLoaded (${timeDelta(
       contentT0,
-      contentT1
-    )}s)`
+      contentT1,
+    )}s)`,
   );
 
   const renderT0 = performance.now();
@@ -113,14 +118,16 @@ export async function captureScreenshot(options: CaptureScreenShotOptions) {
       if (maxTimeInSec > 0) {
         timeout = setTimeout(() => {
           reject(
-            new Error(`Stop capturing screenshot after ${maxTimeInSec} seconds`)
+            new Error(
+              `Stop capturing screenshot after ${maxTimeInSec} seconds`,
+            ),
           );
         }, maxTimeInSec * 1000);
       }
 
-      const modelViewer = document.getElementById("snapshot-viewer");
+      const modelViewer = document.getElementById('snapshot-viewer');
       modelViewer.addEventListener(
-        "poster-dismissed",
+        'poster-dismissed',
         () => {
           requestAnimationFrame(() => {
             requestAnimationFrame(() => {
@@ -133,7 +140,7 @@ export async function captureScreenshot(options: CaptureScreenShotOptions) {
             });
           });
         },
-        { once: true }
+        {once: true},
       );
     });
 
@@ -147,7 +154,7 @@ export async function captureScreenshot(options: CaptureScreenShotOptions) {
 
   const renderT1 = performance.now();
   console.log(
-    `🖌  Rendering screenshot of model (${timeDelta(renderT0, renderT1)}s)`
+    `🖌  Rendering screenshot of model (${timeDelta(renderT0, renderT1)}s)`,
   );
 
   if (evaluateError) {
@@ -160,7 +167,7 @@ export async function captureScreenshot(options: CaptureScreenShotOptions) {
 
   const captureOptions = {
     quality: quality * 100.0,
-    type: formatExtension as "jpeg" | "png" | "webp",
+    type: formatExtension as 'jpeg' | 'png' | 'webp',
     path: outputPath,
     omitBackground: true,
   };
@@ -174,7 +181,7 @@ export async function captureScreenshot(options: CaptureScreenShotOptions) {
   const screenshotT1 = performance.now();
 
   console.log(
-    `🖼  Captured screenshot (${timeDelta(screenshotT0, screenshotT1)}s)`
+    `🖼  Captured screenshot (${timeDelta(screenshotT0, screenshotT1)}s)`,
   );
 
   await browser.close();

--- a/src/check-file-exists-at-url.test.ts
+++ b/src/check-file-exists-at-url.test.ts
@@ -1,8 +1,10 @@
 import {checkFileExistsAtUrl} from './check-file-exists-at-url';
 
 describe('checkFileExistsAtUrl', () => {
-  const urlExists = 'https://cdn.shopify.com/shopifycloud/model-viewer/model-viewer.js';
-  const urlDoesNotExist = 'https://cdn.shopify.com/shopifycloud/dog-viewer/dog-viewer.js'
+  const urlExists =
+    'https://cdn.shopify.com/shopifycloud/model-viewer/model-viewer.js';
+  const urlDoesNotExist =
+    'https://cdn.shopify.com/shopifycloud/dog-viewer/dog-viewer.js';
 
   it('should find the file', async () => {
     await expect(checkFileExistsAtUrl(urlExists)).resolves.toEqual(true);

--- a/src/check-file-exists-at-url.ts
+++ b/src/check-file-exists-at-url.ts
@@ -3,10 +3,7 @@ import https from 'https';
 export function checkFileExistsAtUrl(url: string): Promise<boolean> {
   return new Promise((resolve, reject) => {
     const urlParts = new URL(url);
-    const {
-      hostname,
-      pathname: path,
-    } = urlParts;
+    const {hostname, pathname: path} = urlParts;
 
     const request = https.get(url);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import path from "path";
-import yargs from "yargs/yargs";
+import path from 'path';
+import yargs from 'yargs/yargs';
 
-import { FileServer } from "./file-server";
-import { prepareAppOptions } from "./prepare-app-options";
-import { captureScreenshot } from "./capture-screenshot";
+import {FileServer} from './file-server';
+import {prepareAppOptions} from './prepare-app-options';
+import {captureScreenshot} from './capture-screenshot';
 import {
   DEFAULT_WIDTH,
   DEFAULT_HEIGHT,
@@ -14,79 +14,80 @@ import {
   DEFAULT_TIMEOUT_MILLISECONDS,
   DEFAULT_DEBUG,
   DEFAULT_VERBOSE_LOGGING,
-} from "./defaults";
+} from './defaults';
 
 const argv = yargs(process.argv.slice(2)).options({
   input: {
-    type: "string",
-    alias: "i",
-    describe: "Input glTF 2.0 binary (GLB) filepath",
+    type: 'string',
+    alias: 'i',
+    describe: 'Input glTF 2.0 binary (GLB) filepath',
     demandOption: true,
   },
   output: {
-    type: "string",
-    alias: "o",
-    describe: "Output screenshot filepath",
+    type: 'string',
+    alias: 'o',
+    describe: 'Output screenshot filepath',
     demandOption: true,
   },
   color: {
-    type: "string",
-    alias: "c",
+    type: 'string',
+    alias: 'c',
     describe:
-      "Output image background color (defaults to transparent, accepts HEX or RGB)",
+      'Output image background color (defaults to transparent, accepts HEX or RGB)',
   },
   width: {
-    type: "number",
-    alias: "w",
-    describe: "Output image width",
+    type: 'number',
+    alias: 'w',
+    describe: 'Output image width',
     default: DEFAULT_WIDTH,
   },
   height: {
-    type: "number",
-    alias: "h",
-    describe: "Output image height",
+    type: 'number',
+    alias: 'h',
+    describe: 'Output image height',
     default: DEFAULT_HEIGHT,
   },
   image_format: {
-    type: "string",
-    alias: "f",
+    type: 'string',
+    alias: 'f',
     describe: "Output image format (defaults to 'image/png')",
     default: DEFAULT_FORMAT,
   },
   image_quality: {
-    type: "number",
-    alias: "q",
-    describe: "Quality of the output image",
+    type: 'number',
+    alias: 'q',
+    describe: 'Quality of the output image',
     default: DEFAULT_QUALITY,
   },
   timeout: {
-    type: "number",
-    alias: "t",
-    describe: "Timeout length in milliseconds",
+    type: 'number',
+    alias: 't',
+    describe: 'Timeout length in milliseconds',
     default: DEFAULT_TIMEOUT_MILLISECONDS,
   },
   debug: {
-    type: "boolean",
-    alias: "d",
-    describe: "Enable Debug Mode",
+    type: 'boolean',
+    alias: 'd',
+    describe: 'Enable Debug Mode',
     default: DEFAULT_DEBUG,
   },
   verbose: {
-    type: "boolean",
-    alias: "v",
-    describe: "Enable verbose logging",
+    type: 'boolean',
+    alias: 'v',
+    describe: 'Enable verbose logging',
     default: DEFAULT_VERBOSE_LOGGING,
   },
   model_viewer_version: {
-    type: "string",
-    alias: "@",
-    describe: "Model viewer version to be used. If nothing is passed defaults to latest"
+    type: 'string',
+    alias: '@',
+    describe:
+      'Model viewer version to be used. If nothing is passed defaults to latest',
   },
   model_viewer_attributes: {
-    type: "string",
-    alias: "m",
+    type: 'string',
+    alias: 'm',
     describe:
-      "Set <model-viewer> attributes by passing them as url params eg. exposure=2&environment-image=neutral",
+      'Set <model-viewer> attributes by passing them as url params eg. exposure=2&environment-image=neutral',
   },
 }).argv;
 
@@ -102,7 +103,7 @@ const argv = yargs(process.argv.slice(2)).options({
 
   let processStatus = 0;
   try {
-    await captureScreenshot({ ...options, devicePixelRatio: 1.0 });
+    await captureScreenshot({...options, devicePixelRatio: 1.0});
   } catch (err) {
     console.log(`❌ Unhandled: ${err}`);
     processStatus = 1;

--- a/src/colors.ts
+++ b/src/colors.ts
@@ -1,4 +1,4 @@
 export const colors = {
-  white: "rgba(255, 255, 255, 1)",
-  transparent: "rgba(255, 255, 255, 0)",
+  white: 'rgba(255, 255, 255, 1)',
+  transparent: 'rgba(255, 255, 255, 0)',
 };

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,6 +1,6 @@
 export const DEFAULT_WIDTH = 1024;
 export const DEFAULT_HEIGHT = 1024;
-export const DEFAULT_FORMAT = "image/png";
+export const DEFAULT_FORMAT = 'image/png';
 export const DEFAULT_QUALITY = 0.92;
 export const DEFAULT_TIMEOUT_MILLISECONDS = 30 * 1000;
 export const DEFAULT_DEBUG = false;

--- a/src/file-server.ts
+++ b/src/file-server.ts
@@ -1,39 +1,39 @@
-import http from "http";
-import fs from "fs";
-import path from "path";
-import { AddressInfo } from "net";
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import {AddressInfo} from 'net';
 
 const createFileServer = (mountDirectory) => {
   return http.createServer((request, response) => {
     const filePath = path.join(mountDirectory, request.url);
     const extname = String(path.extname(filePath)).toLowerCase();
     const mimeTypes = {
-      ".glb": "application/gltf-binary",
-      ".js": "application/javascript",
+      '.glb': 'application/gltf-binary',
+      '.js': 'application/javascript',
     };
 
-    const contentType = mimeTypes[extname] || "application/octet-stream";
+    const contentType = mimeTypes[extname] || 'application/octet-stream';
     const headers = {
-      "Content-Type": contentType,
-      "Access-Control-Allow-Origin": "*",
+      'Content-Type': contentType,
+      'Access-Control-Allow-Origin': '*',
     };
 
     fs.readFile(filePath, (error, content) => {
       if (error) {
-        if (error.code == "ENOENT") {
+        if (error.code == 'ENOENT') {
           response.writeHead(404, headers);
-          response.end("File not found", "utf-8");
+          response.end('File not found', 'utf-8');
         } else {
           response.writeHead(500);
           response.end(
-            "Sorry, check with the site admin for error: " +
+            'Sorry, check with the site admin for error: ' +
               error.code +
-              " ..\n"
+              ' ..\n',
           );
         }
       } else {
         response.writeHead(200, headers);
-        response.end(content, "utf-8");
+        response.end(content, 'utf-8');
       }
     });
   });

--- a/src/get-model-viewer-url.test.ts
+++ b/src/get-model-viewer-url.test.ts
@@ -2,38 +2,56 @@ import {getModelViewerUrl} from './get-model-viewer-url';
 
 describe('getModelViewerUrl', () => {
   it('handles default', () => {
-    expect(getModelViewerUrl()).toBe('https://cdn.shopify.com/shopifycloud/model-viewer/model-viewer.js');
+    expect(getModelViewerUrl()).toBe(
+      'https://cdn.shopify.com/shopifycloud/model-viewer/model-viewer.js',
+    );
   });
 
   it('handles passing version', () => {
-    expect(getModelViewerUrl('1.9')).toBe('https://cdn.shopify.com/shopifycloud/model-viewer/v1.9/model-viewer.js');
+    expect(getModelViewerUrl('1.9')).toBe(
+      'https://cdn.shopify.com/shopifycloud/model-viewer/v1.9/model-viewer.js',
+    );
   });
 
   it('handles passing full version', () => {
-    expect(getModelViewerUrl('1.9.1')).toBe('https://cdn.shopify.com/shopifycloud/model-viewer/v1.9/model-viewer.js');
+    expect(getModelViewerUrl('1.9.1')).toBe(
+      'https://cdn.shopify.com/shopifycloud/model-viewer/v1.9/model-viewer.js',
+    );
   });
 
   it('handles passing with v', () => {
-    expect(getModelViewerUrl('v1.9')).toBe('https://cdn.shopify.com/shopifycloud/model-viewer/v1.9/model-viewer.js');
+    expect(getModelViewerUrl('v1.9')).toBe(
+      'https://cdn.shopify.com/shopifycloud/model-viewer/v1.9/model-viewer.js',
+    );
   });
 
   it('handles passing with v and full version', () => {
-    expect(getModelViewerUrl('v1.9.1')).toBe('https://cdn.shopify.com/shopifycloud/model-viewer/v1.9/model-viewer.js');
+    expect(getModelViewerUrl('v1.9.1')).toBe(
+      'https://cdn.shopify.com/shopifycloud/model-viewer/v1.9/model-viewer.js',
+    );
   });
 
   it('handles multi digit', () => {
-    expect(getModelViewerUrl('11.99.1')).toBe('https://cdn.shopify.com/shopifycloud/model-viewer/v11.99/model-viewer.js');
+    expect(getModelViewerUrl('11.99.1')).toBe(
+      'https://cdn.shopify.com/shopifycloud/model-viewer/v11.99/model-viewer.js',
+    );
   });
 
   it('handles passing with v', () => {
-    expect(getModelViewerUrl('v11.99')).toBe('https://cdn.shopify.com/shopifycloud/model-viewer/v11.99/model-viewer.js');
+    expect(getModelViewerUrl('v11.99')).toBe(
+      'https://cdn.shopify.com/shopifycloud/model-viewer/v11.99/model-viewer.js',
+    );
   });
 
   it('handles passing with v and full version', () => {
-    expect(getModelViewerUrl('v11.99.1')).toBe('https://cdn.shopify.com/shopifycloud/model-viewer/v11.99/model-viewer.js');
+    expect(getModelViewerUrl('v11.99.1')).toBe(
+      'https://cdn.shopify.com/shopifycloud/model-viewer/v11.99/model-viewer.js',
+    );
   });
 
   it('handles no version', () => {
-    expect(() => getModelViewerUrl('dogs.are.cool')).toThrow('"dogs.are.cool" was not valid version. Example version: 1.10');
+    expect(() => getModelViewerUrl('dogs.are.cool')).toThrow(
+      '"dogs.are.cool" was not valid version. Example version: 1.10',
+    );
   });
 });

--- a/src/get-model-viewer-url.ts
+++ b/src/get-model-viewer-url.ts
@@ -8,7 +8,9 @@ export function getModelViewerUrl(version?: string) {
   const result = regexGetVersion.exec(version);
 
   if (!result) {
-    throw new Error(`"${version}" was not valid version. Example version: 1.10`);
+    throw new Error(
+      `"${version}" was not valid version. Example version: 1.10`,
+    );
   }
 
   const majorMinor = result[1];

--- a/src/html-template.test.ts
+++ b/src/html-template.test.ts
@@ -2,34 +2,35 @@
  * @jest-environment jsdom
  */
 
-import { htmlTemplate } from "./html-template";
+import {htmlTemplate} from './html-template';
 
-describe("htmlTemplate", () => {
+describe('htmlTemplate', () => {
   const defaultOptions = {
-    modelViewerUrl: 'https://cdn.shopify.com/shopifycloud/model-viewer/model-viewer.js',
+    modelViewerUrl:
+      'https://cdn.shopify.com/shopifycloud/model-viewer/model-viewer.js',
     width: 3051,
     height: 768,
-    inputPath: "http://localhost:8081/some_model.glb",
-    backgroundColor: "#CAFE00",
+    inputPath: 'http://localhost:8081/some_model.glb',
+    backgroundColor: '#CAFE00',
     devicePixelRatio: 1.0,
   };
 
-  describe("style", () => {
-    it("should render", () => {
-      const { width, height } = defaultOptions;
+  describe('style', () => {
+    it('should render', () => {
+      const {width, height} = defaultOptions;
       document.documentElement.innerHTML = htmlTemplate(defaultOptions);
 
       expect(document.styleSheets).toHaveLength(1);
       expect(document.styleSheets[0].cssRules).toHaveLength(2);
       expect(document.styleSheets[0].cssRules[0].cssText).toEqual(
-        "body {margin: 0;}"
+        'body {margin: 0;}',
       );
       expect(document.styleSheets[0].cssRules[1].cssText).toEqual(
-        `model-viewer {--progress-bar-color: transparent; width: ${width}px; height: ${height}px;}`
+        `model-viewer {--progress-bar-color: transparent; width: ${width}px; height: ${height}px;}`,
       );
     });
 
-    it("should handle width and height", () => {
+    it('should handle width and height', () => {
       const width = 8080;
       const height = 8888;
       document.documentElement.innerHTML = htmlTemplate({
@@ -39,25 +40,25 @@ describe("htmlTemplate", () => {
       });
 
       expect(document.styleSheets[0].cssRules[1].cssText).toEqual(
-        `model-viewer {--progress-bar-color: transparent; width: ${width}px; height: ${height}px;}`
+        `model-viewer {--progress-bar-color: transparent; width: ${width}px; height: ${height}px;}`,
       );
     });
   });
 
-  describe("meta", () => {
-    it("should render", () => {
+  describe('meta', () => {
+    it('should render', () => {
       document.documentElement.innerHTML = htmlTemplate(defaultOptions);
 
-      const metaTags = document.querySelectorAll("meta");
+      const metaTags = document.querySelectorAll('meta');
 
       expect(metaTags).toHaveLength(1);
-      expect(metaTags[0].getAttribute("name")).toBe("viewport");
-      expect(metaTags[0].getAttribute("content")).toBe(
-        `width=device-width, initial-scale=${devicePixelRatio}`
+      expect(metaTags[0].getAttribute('name')).toBe('viewport');
+      expect(metaTags[0].getAttribute('content')).toBe(
+        `width=device-width, initial-scale=${devicePixelRatio}`,
       );
     });
 
-    it("should handle devicePixelRatio", () => {
+    it('should handle devicePixelRatio', () => {
       const devicePixelRatio = 0.123;
 
       document.documentElement.innerHTML = htmlTemplate({
@@ -65,90 +66,90 @@ describe("htmlTemplate", () => {
         devicePixelRatio,
       });
 
-      const metaTag = document.querySelector("meta");
+      const metaTag = document.querySelector('meta');
 
-      expect(metaTag.getAttribute("content")).toBe(
-        "width=device-width, initial-scale=0.123"
+      expect(metaTag.getAttribute('content')).toBe(
+        'width=device-width, initial-scale=0.123',
       );
     });
   });
 
-  describe("script", () => {
-    it("should render", () => {
+  describe('script', () => {
+    it('should render', () => {
       document.documentElement.innerHTML = htmlTemplate(defaultOptions);
 
-      const scriptTags = document.querySelectorAll("script");
+      const scriptTags = document.querySelectorAll('script');
 
       expect(scriptTags).toHaveLength(1);
-      expect(scriptTags[0].getAttribute("type")).toBe("module");
-      expect(scriptTags[0].getAttribute("src")).toBe(
-        'https://cdn.shopify.com/shopifycloud/model-viewer/model-viewer.js'
+      expect(scriptTags[0].getAttribute('type')).toBe('module');
+      expect(scriptTags[0].getAttribute('src')).toBe(
+        'https://cdn.shopify.com/shopifycloud/model-viewer/model-viewer.js',
       );
     });
 
-    it("should handle port", () => {
+    it('should handle port', () => {
       document.documentElement.innerHTML = htmlTemplate({
         ...defaultOptions,
       });
 
-      const script = document.querySelector("script");
+      const script = document.querySelector('script');
 
-      expect(script.getAttribute("src")).toBe(
-        'https://cdn.shopify.com/shopifycloud/model-viewer/model-viewer.js'
+      expect(script.getAttribute('src')).toBe(
+        'https://cdn.shopify.com/shopifycloud/model-viewer/model-viewer.js',
       );
     });
   });
 
-  describe("model-viewer", () => {
-    it("should render", () => {
-      const { inputPath, backgroundColor } = defaultOptions;
+  describe('model-viewer', () => {
+    it('should render', () => {
+      const {inputPath, backgroundColor} = defaultOptions;
 
       document.documentElement.innerHTML = htmlTemplate(defaultOptions);
 
-      const modelViewers = document.querySelectorAll("model-viewer");
+      const modelViewers = document.querySelectorAll('model-viewer');
       expect(modelViewers).toHaveLength(1);
 
       const modelViewer = modelViewers[0];
       expect(modelViewer).toBeTruthy();
 
-      expect(modelViewer.getAttribute("id")).toEqual("snapshot-viewer");
-      expect(modelViewer.getAttribute("interaction-prompt")).toEqual("none");
-      expect(modelViewer.getAttribute("src")).toEqual(inputPath);
-      expect(modelViewer.getAttribute("style")).toEqual(
-        `background-color: ${backgroundColor};`
+      expect(modelViewer.getAttribute('id')).toEqual('snapshot-viewer');
+      expect(modelViewer.getAttribute('interaction-prompt')).toEqual('none');
+      expect(modelViewer.getAttribute('src')).toEqual(inputPath);
+      expect(modelViewer.getAttribute('style')).toEqual(
+        `background-color: ${backgroundColor};`,
       );
     });
 
-    it("should handle inputPath", () => {
-      const inputPath = "new.glb";
+    it('should handle inputPath', () => {
+      const inputPath = 'new.glb';
       document.documentElement.innerHTML = htmlTemplate({
         ...defaultOptions,
         inputPath,
       });
 
-      const modelViewer = document.querySelector("model-viewer");
+      const modelViewer = document.querySelector('model-viewer');
 
-      expect(modelViewer.getAttribute("src")).toEqual(inputPath);
+      expect(modelViewer.getAttribute('src')).toEqual(inputPath);
     });
 
-    it("should handle backgroundColor", () => {
-      const backgroundColor = "#FACE00";
+    it('should handle backgroundColor', () => {
+      const backgroundColor = '#FACE00';
       document.documentElement.innerHTML = htmlTemplate({
         ...defaultOptions,
         backgroundColor,
       });
 
-      const modelViewer = document.querySelector("model-viewer");
+      const modelViewer = document.querySelector('model-viewer');
 
-      expect(modelViewer.getAttribute("style")).toEqual(
-        `background-color: ${backgroundColor};`
+      expect(modelViewer.getAttribute('style')).toEqual(
+        `background-color: ${backgroundColor};`,
       );
     });
 
-    it("should pass custom attributes", () => {
+    it('should pass custom attributes', () => {
       const modelViewerArgs = {
-        "environment-image": "https://some-url.hdr",
-        exposure: "3",
+        'environment-image': 'https://some-url.hdr',
+        exposure: '3',
       };
 
       document.documentElement.innerHTML = htmlTemplate({
@@ -156,76 +157,76 @@ describe("htmlTemplate", () => {
         modelViewerArgs,
       });
 
-      const modelViewer = document.querySelector("model-viewer");
+      const modelViewer = document.querySelector('model-viewer');
 
       Object.entries(modelViewerArgs).forEach(([attribute, value]) => {
         expect(modelViewer.getAttribute(attribute)).toBe(value);
       });
     });
 
-    it("cannot overwrite src", () => {
+    it('cannot overwrite src', () => {
       const modelViewerArgs = {
-        src: "new-source.glb",
+        src: 'new-source.glb',
       };
 
       expect(() =>
         htmlTemplate({
           ...defaultOptions,
           modelViewerArgs,
-        })
+        }),
       ).toThrow(
-        new Error("`src` cannot be ovewritten pass the source via -i instead")
+        new Error('`src` cannot be ovewritten pass the source via -i instead'),
       );
     });
 
-    it("cannot overwrite id", () => {
+    it('cannot overwrite id', () => {
       const modelViewerArgs = {
-        id: "an-id",
+        id: 'an-id',
       };
 
       expect(() =>
         htmlTemplate({
           ...defaultOptions,
           modelViewerArgs,
-        })
+        }),
       ).toThrow(
         new Error(
-          "`id` cannot be passed since it would cause the renderer to break"
-        )
+          '`id` cannot be passed since it would cause the renderer to break',
+        ),
       );
     });
 
-    it("cannot overwrite interaction-prompt", () => {
+    it('cannot overwrite interaction-prompt', () => {
       const modelViewerArgs = {
-        "interaction-prompt": "when-focused",
+        'interaction-prompt': 'when-focused',
       };
 
       expect(() =>
         htmlTemplate({
           ...defaultOptions,
           modelViewerArgs,
-        })
+        }),
       ).toThrow(
         new Error(
-          "`interaction-prompt` cannot be passed since it would cause unexpected renders"
-        )
+          '`interaction-prompt` cannot be passed since it would cause unexpected renders',
+        ),
       );
     });
 
-    it("cannot overwrite style", () => {
+    it('cannot overwrite style', () => {
       const modelViewerArgs = {
-        style: "color: #FF00FF",
+        style: 'color: #FF00FF',
       };
 
       expect(() =>
         htmlTemplate({
           ...defaultOptions,
           modelViewerArgs,
-        })
+        }),
       ).toThrow(
         new Error(
-          "`style` cannot be passed since it would cause unexpected renders"
-        )
+          '`style` cannot be passed since it would cause unexpected renders',
+        ),
       );
     });
   });

--- a/src/html-template.ts
+++ b/src/html-template.ts
@@ -1,6 +1,6 @@
-import {getModelViewerUrl} from "./get-model-viewer-url";
+import {getModelViewerUrl} from './get-model-viewer-url';
 
-type AttributesObject = { [key: string]: any };
+type AttributesObject = {[key: string]: any};
 
 export interface TemplateRenderOptions {
   modelViewerUrl: string;
@@ -13,26 +13,26 @@ export interface TemplateRenderOptions {
 }
 
 function toHTMLAttributeString(args: AttributesObject | undefined) {
-  if (!args) return "";
+  if (!args) return '';
 
   return Object.entries(args)
     .map(([key, value]) => {
       return `${key}="${value}"`;
     })
-    .join("\n");
+    .join('\n');
 }
 
 const errorMessagesForAttributeKey = {
-  src: "`src` cannot be ovewritten pass the source via -i instead",
-  "interaction-prompt":
-    "`interaction-prompt` cannot be passed since it would cause unexpected renders",
-  style: "`style` cannot be passed since it would cause unexpected renders",
-  id: "`id` cannot be passed since it would cause the renderer to break",
+  src: '`src` cannot be ovewritten pass the source via -i instead',
+  'interaction-prompt':
+    '`interaction-prompt` cannot be passed since it would cause unexpected renders',
+  style: '`style` cannot be passed since it would cause unexpected renders',
+  id: '`id` cannot be passed since it would cause the renderer to break',
 };
 
 function validateCustomAttributes(
   defaultAttributes: AttributesObject,
-  customAttributes: AttributesObject | undefined
+  customAttributes: AttributesObject | undefined,
 ) {
   if (!customAttributes) {
     return;
@@ -59,9 +59,9 @@ export function htmlTemplate({
   modelViewerArgs,
 }: TemplateRenderOptions): string {
   const defaultAttributes = {
-    id: "snapshot-viewer",
+    id: 'snapshot-viewer',
     style: `background-color: ${backgroundColor};`,
-    "interaction-prompt": "none",
+    'interaction-prompt': 'none',
     src: inputPath,
   };
 

--- a/src/parse-output-path-and-format.test.ts
+++ b/src/parse-output-path-and-format.test.ts
@@ -1,66 +1,66 @@
-import { parseOutputPathAndFormat } from "./parse-output-path-and-format";
+import {parseOutputPathAndFormat} from './parse-output-path-and-format';
 
-describe("parseOutputPathAndFormat", () => {
-  it("handles jpg", () => {
-    expect(parseOutputPathAndFormat("image.jpg", "image/jpeg")).toEqual([
-      "image.jpg",
-      "image/jpeg",
-      "jpeg",
+describe('parseOutputPathAndFormat', () => {
+  it('handles jpg', () => {
+    expect(parseOutputPathAndFormat('image.jpg', 'image/jpeg')).toEqual([
+      'image.jpg',
+      'image/jpeg',
+      'jpeg',
     ]);
   });
 
-  it("handles png", () => {
-    expect(parseOutputPathAndFormat("image.png", "image/png")).toEqual([
-      "image.png",
-      "image/png",
-      "png",
+  it('handles png', () => {
+    expect(parseOutputPathAndFormat('image.png', 'image/png')).toEqual([
+      'image.png',
+      'image/png',
+      'png',
     ]);
   });
 
-  it("handles name with period", () => {
-    expect(parseOutputPathAndFormat("image.something", "image/jpeg")).toEqual([
-      "image.something.jpg",
-      "image/jpeg",
-      "jpeg",
+  it('handles name with period', () => {
+    expect(parseOutputPathAndFormat('image.something', 'image/jpeg')).toEqual([
+      'image.something.jpg',
+      'image/jpeg',
+      'jpeg',
     ]);
   });
 
-  it("handles mismatched image and format", () => {
-    expect(parseOutputPathAndFormat("image.jpg", "image/png")).toEqual([
-      "image.jpg",
-      "image/jpeg",
-      "jpeg",
+  it('handles mismatched image and format', () => {
+    expect(parseOutputPathAndFormat('image.jpg', 'image/png')).toEqual([
+      'image.jpg',
+      'image/jpeg',
+      'jpeg',
     ]);
 
-    expect(parseOutputPathAndFormat("image.png", "image/jpeg")).toEqual([
-      "image.png",
-      "image/png",
-      "png",
-    ]);
-  });
-
-  it("handles missing extension", () => {
-    expect(parseOutputPathAndFormat("image", "image/png")).toEqual([
-      "image.png",
-      "image/png",
-      "png",
-    ]);
-
-    expect(parseOutputPathAndFormat("image", "image/jpeg")).toEqual([
-      "image.jpg",
-      "image/jpeg",
-      "jpeg",
+    expect(parseOutputPathAndFormat('image.png', 'image/jpeg')).toEqual([
+      'image.png',
+      'image/png',
+      'png',
     ]);
   });
 
-  it("handles when format cannot be determined from the extension or format", () => {
-    const path = "image";
-    const format = "who-knows";
+  it('handles missing extension', () => {
+    expect(parseOutputPathAndFormat('image', 'image/png')).toEqual([
+      'image.png',
+      'image/png',
+      'png',
+    ]);
+
+    expect(parseOutputPathAndFormat('image', 'image/jpeg')).toEqual([
+      'image.jpg',
+      'image/jpeg',
+      'jpeg',
+    ]);
+  });
+
+  it('handles when format cannot be determined from the extension or format', () => {
+    const path = 'image';
+    const format = 'who-knows';
 
     expect(() => parseOutputPathAndFormat(path, format)).toThrow(
       new Error(
-        `Could not determine image type from path: 'image' or from the format 'who-knows'.\n\nYou can try passing a image_format of 'image/jpeg' or 'image/png'`
-      )
+        `Could not determine image type from path: 'image' or from the format 'who-knows'.\n\nYou can try passing a image_format of 'image/jpeg' or 'image/png'`,
+      ),
     );
   });
 });

--- a/src/parse-output-path-and-format.ts
+++ b/src/parse-output-path-and-format.ts
@@ -1,13 +1,13 @@
-const mime = require("mime-types");
-const path = require("path");
+const mime = require('mime-types');
+const path = require('path');
 
 function cleanExtension(extension: string): string {
-  let cleanedExtension = extension.replace(/^\./, "");
+  let cleanedExtension = extension.replace(/^\./, '');
 
-  if (cleanedExtension === "jpg") {
-    return "jpeg";
+  if (cleanedExtension === 'jpg') {
+    return 'jpeg';
   }
-  
+
   return cleanedExtension;
 }
 
@@ -23,12 +23,16 @@ export function parseOutputPathAndFormat(output: string, format: string) {
 
   if (!formatExtension) {
     throw new Error(
-      `Could not determine image type from path: '${output}' or from the format '${format}'.\n\nYou can try passing a image_format of 'image/jpeg' or 'image/png'`
+      `Could not determine image type from path: '${output}' or from the format '${format}'.\n\nYou can try passing a image_format of 'image/jpeg' or 'image/png'`,
     );
   }
 
   const friendlyExtensionOutput =
-    formatExtension === "jpeg" ? "jpg" : formatExtension;
+    formatExtension === 'jpeg' ? 'jpg' : formatExtension;
 
-  return [`${output}.${friendlyExtensionOutput}`, format, cleanExtension(friendlyExtensionOutput)];
+  return [
+    `${output}.${friendlyExtensionOutput}`,
+    format,
+    cleanExtension(friendlyExtensionOutput),
+  ];
 }

--- a/src/prepare-app-options.test.ts
+++ b/src/prepare-app-options.test.ts
@@ -1,26 +1,26 @@
-import { prepareAppOptions } from "./prepare-app-options";
+import {prepareAppOptions} from './prepare-app-options';
 
 const modelPort = 8081;
 const debug = false;
 
 const defaultPreparedOptions = {
-  backgroundColor: "rgba(255, 255, 255, 0)",
+  backgroundColor: 'rgba(255, 255, 255, 0)',
   debug: false,
-  format: "image/png",
-  formatExtension: "png",
+  format: 'image/png',
+  formatExtension: 'png',
   width: 1024,
   height: 1024,
-  inputPath: "http://localhost:8081/some_model.glb",
-  outputPath: "./some_image.png",
+  inputPath: 'http://localhost:8081/some_model.glb',
+  outputPath: './some_image.png',
   quality: 0.92,
   timeout: 10000,
 };
 
 function getArgv(optionalAndOverrides = {}) {
   const required = {
-    input: "./some_model.glb",
-    output: "./some_image.png",
-    image_format: "image/png",
+    input: './some_model.glb',
+    output: './some_image.png',
+    image_format: 'image/png',
     width: 1024,
     height: 1024,
     image_quality: 0.92,
@@ -33,18 +33,18 @@ function getArgv(optionalAndOverrides = {}) {
   };
 }
 
-test("handles args", () => {
+test('handles args', () => {
   const argv = getArgv({
     width: 2048,
     height: 2048,
     timeout: 2000,
     image_quality: 1,
-    color: "rgba(255, 0, 255, 0)",
+    color: 'rgba(255, 0, 255, 0)',
   });
 
-  expect(prepareAppOptions({ modelPort, debug, argv })).toEqual({
+  expect(prepareAppOptions({modelPort, debug, argv})).toEqual({
     ...defaultPreparedOptions,
-    backgroundColor: "rgba(255, 0, 255, 0)",
+    backgroundColor: 'rgba(255, 0, 255, 0)',
     width: 2048,
     height: 2048,
     quality: 1,
@@ -52,46 +52,46 @@ test("handles args", () => {
   });
 });
 
-test("handles jpg format", () => {
+test('handles jpg format', () => {
   const argv = getArgv({
-    output: "./some_image.jpg",
-    image_format: "image/jpeg",
+    output: './some_image.jpg',
+    image_format: 'image/jpeg',
   });
 
-  expect(prepareAppOptions({ modelPort, debug, argv })).toEqual({
+  expect(prepareAppOptions({modelPort, debug, argv})).toEqual({
     ...defaultPreparedOptions,
-    outputPath: "./some_image.jpg",
-    format: "image/jpeg",
-    formatExtension: "jpeg",
-    backgroundColor: "rgba(255, 255, 255, 1)",
+    outputPath: './some_image.jpg',
+    format: 'image/jpeg',
+    formatExtension: 'jpeg',
+    backgroundColor: 'rgba(255, 255, 255, 1)',
   });
 });
 
-test("handles jpg with color override", () => {
+test('handles jpg with color override', () => {
   const argv = getArgv({
-    output: "./some_image.jpg",
-    image_format: "image/jpeg",
-    color: "rgba(255, 0, 255, 1)",
+    output: './some_image.jpg',
+    image_format: 'image/jpeg',
+    color: 'rgba(255, 0, 255, 1)',
   });
 
-  expect(prepareAppOptions({ modelPort, debug, argv })).toEqual({
+  expect(prepareAppOptions({modelPort, debug, argv})).toEqual({
     ...defaultPreparedOptions,
-    outputPath: "./some_image.jpg",
-    format: "image/jpeg",
-    formatExtension: "jpeg",
-    backgroundColor: "rgba(255, 0, 255, 1)",
+    outputPath: './some_image.jpg',
+    format: 'image/jpeg',
+    formatExtension: 'jpeg',
+    backgroundColor: 'rgba(255, 0, 255, 1)',
   });
 });
 
-test("handles model viewer attributes", () => {
+test('handles model viewer attributes', () => {
   const argv = getArgv({
-    model_viewer_attributes: "exposure=10&camera-orbit=45deg 55deg 2.5m",
+    model_viewer_attributes: 'exposure=10&camera-orbit=45deg 55deg 2.5m',
   });
-  expect(prepareAppOptions({ modelPort, debug, argv })).toEqual({
+  expect(prepareAppOptions({modelPort, debug, argv})).toEqual({
     ...defaultPreparedOptions,
     modelViewerArgs: {
-      "camera-orbit": "45deg 55deg 2.5m",
-      exposure: "10",
+      'camera-orbit': '45deg 55deg 2.5m',
+      exposure: '10',
     },
   });
 });

--- a/src/prepare-app-options.ts
+++ b/src/prepare-app-options.ts
@@ -1,7 +1,7 @@
-import path from "path";
+import path from 'path';
 
-import { parseOutputPathAndFormat } from "./parse-output-path-and-format";
-import { colors } from "./colors";
+import {parseOutputPathAndFormat} from './parse-output-path-and-format';
+import {colors} from './colors';
 
 interface Argv {
   input: string;
@@ -22,7 +22,7 @@ interface Props {
   debug?: boolean;
 }
 
-export function prepareAppOptions({ modelPort, debug, argv }: Props) {
+export function prepareAppOptions({modelPort, debug, argv}: Props) {
   const {
     input,
     output,
@@ -36,10 +36,13 @@ export function prepareAppOptions({ modelPort, debug, argv }: Props) {
     model_viewer_version: modelViewerVersion,
   } = argv;
   const inputPath = `http://localhost:${modelPort}/${path.basename(input)}`;
-  const [outputPath, format, formatExtension] = parseOutputPathAndFormat(output, image_format);
+  const [outputPath, format, formatExtension] = parseOutputPathAndFormat(
+    output,
+    image_format,
+  );
   const defaultBackgroundColor =
-    format === "image/jpeg" ? colors.white : colors.transparent;
-  let modelViewerArgs: { [key: string]: string } = undefined;
+    format === 'image/jpeg' ? colors.white : colors.transparent;
+  let modelViewerArgs: {[key: string]: string} = undefined;
 
   if (model_viewer_attributes) {
     modelViewerArgs = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -502,6 +502,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@shopify/prettier-config@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@shopify/prettier-config/-/prettier-config-1.1.2.tgz#612f87c0cd1196e8b43c85425e587d0fa7f1172d"
+  integrity sha512-5ugCL9sPGzmOaZjeRGaWUWhHgAbemrS6z+R7v6gwiD+BiqSeoFhIY+imLpfdFCVpuOGalpHeCv6o3gv++EHs0A==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -2202,6 +2207,11 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+
+prettier@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-format@^27.0.0, pretty-format@^27.5.1:
   version "27.5.1"


### PR DESCRIPTION
This PR adds prettier to `screenshot-glb`

- Adds the Shopify prettier default config `@shopify/prettier-config`
- Added two NPM scripts
  - `yarn lint` - Lints the files
  - `yarn lint:fix` - Automatically formats all files (should be noted there's no need to use this if you have a plugin installed in your editor)