### PR TITLE
Uses tmp folder

### DIFF
--- a/src/__mocks__/file-handler.ts
+++ b/src/__mocks__/file-handler.ts
@@ -1,0 +1,16 @@
+import path from 'path';
+
+function FileHandler() {}
+
+FileHandler.prototype = {
+  addFile: jest.fn().mockImplementation((filePath: string) => {
+    return Promise.resolve(path.basename(filePath));
+  }),
+  stop: jest.fn(),
+};
+
+Object.defineProperty(FileHandler.prototype, 'fileDirectory', {
+  get: jest.fn().mockReturnValue('/tmp'),
+});
+
+export {FileHandler};

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import yargs from 'yargs/yargs';
 
 import {FileServer} from './file-server';
+import {FileHandler} from './file-handler';
 import {prepareAppOptions} from './prepare-app-options';
 import {captureScreenshot} from './capture-screenshot';
 import {
@@ -101,12 +102,13 @@ const argv = yargs(process.argv.slice(2)).options({
 (async () => {
   async function closeProgram() {
     await localServer.stop();
+    await fileHandler.destroy();
 
     process.exit(processStatus);
   }
 
-  const localServerPath = path.dirname(argv.input);
-  const localServer = new FileServer(localServerPath);
+  const fileHandler = new FileHandler();
+  const localServer = new FileServer(fileHandler.fileDirectory);
   let options: CaptureScreenShotOptions;
   let processStatus = 0;
 
@@ -115,7 +117,7 @@ const argv = yargs(process.argv.slice(2)).options({
   try {
     options = await prepareAppOptions({
       localServerPort: localServer.port,
-      localServerPath,
+      fileHandler,
       argv,
     });
   } catch (error) {

--- a/src/file-handler.test.ts
+++ b/src/file-handler.test.ts
@@ -1,0 +1,65 @@
+import {copyFile, rm} from 'fs';
+
+import {FileHandler} from './file-handler';
+
+jest.mock('os', () => {
+  return {
+    tmpdir: jest.fn(() => '/os-tmp'),
+  };
+});
+
+jest.mock('fs', () => {
+  return {
+    rm: jest.fn(),
+    copyFile: jest.fn(),
+    mkdtempSync: jest.fn((base: string) => `${base}/tmp-folder`),
+  };
+});
+
+jest.mock('path', () => {
+  const path = jest.requireActual('path');
+
+  return {
+    ...path,
+    resolve: jest.fn((filePath: string) => filePath.replace('.', '/resolved')),
+  };
+});
+
+afterEach(jest.clearAllMocks);
+
+describe('FileHandler', () => {
+  let fileHandler: FileHandler;
+
+  beforeEach(() => {
+    fileHandler = new FileHandler();
+  });
+
+  it('creates a temp folder', () => {
+    expect(fileHandler.fileDirectory).toEqual(
+      '/os-tmp/screenshot-glb/tmp-folder',
+    );
+  });
+
+  it('copies file during add', () => {
+    fileHandler.addFile('./some.glb');
+
+    expect(copyFile).toHaveBeenCalledTimes(1);
+    expect((copyFile as any as jest.Mock).mock.calls[0][0]).toEqual(
+      '/resolved/some.glb',
+    );
+    expect((copyFile as any as jest.Mock).mock.calls[0][1]).toEqual(
+      '/os-tmp/screenshot-glb/tmp-folder/some.glb',
+    );
+  });
+
+  it('deletes temp folder on stop', () => {
+    fileHandler.destroy();
+
+    expect((rm as any as jest.Mock).mock.calls[0][0] as string).toEqual(
+      '/os-tmp/screenshot-glb/tmp-folder',
+    );
+    expect((rm as any as jest.Mock).mock.calls[0][1] as any).toEqual({
+      recursive: true,
+    });
+  });
+});

--- a/src/file-handler.ts
+++ b/src/file-handler.ts
@@ -1,0 +1,32 @@
+import os from 'os';
+import path from 'path';
+import {copyFile as copyFileNode, rm as rmNode, mkdtempSync} from 'fs';
+import {promisify} from 'util';
+
+const copyFile = promisify(copyFileNode);
+const rm = promisify(rmNode);
+
+export class FileHandler {
+  get fileDirectory(): string {
+    return this._fileDirectory;
+  }
+
+  private _fileDirectory: string;
+
+  constructor() {
+    this._fileDirectory = mkdtempSync(path.join(os.tmpdir(), 'screenshot-glb'));
+  }
+
+  async addFile(filePath: string): Promise<string> {
+    const fileName = path.basename(filePath);
+    await copyFile(
+      path.resolve(filePath),
+      path.join(this._fileDirectory, fileName),
+    );
+    return fileName;
+  }
+
+  async destroy() {
+    await rm(this._fileDirectory, {recursive: true});
+  }
+}


### PR DESCRIPTION
In our current implementation the folder that the glb lives in is served entirely.

When using a local `model-viewer.js` we copied this file to the folder where the glb lived. Unfortunately we never deleted this file.

I didn't really like how we were serving the entire folder where the glb lives also.

So now what happens is that a temporary file is created and assets that need to be served are copied to it.